### PR TITLE
Add Optic to track + test API changes

### DIFF
--- a/.github/workflows/optic.yml
+++ b/.github/workflows/optic.yml
@@ -1,0 +1,22 @@
+name: optic
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+ 
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+ 
+      - name: Install Optic
+        run: npm install --location global @useoptic/optic
+ 
+      - name: Run Optic
+        env:
+          OPTIC_TOKEN: ${{ secrets.OPTIC_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: optic run

--- a/optic.yml
+++ b/optic.yml
@@ -1,0 +1,9 @@
+ruleset:
+ - "breaking-changes"
+ - naming:
+    required_on: added
+    requestHeaders: Capital-Param-Case
+    responseHeaders: Capital-Param-Case
+    properties: snake_case
+    pathComponents:  snake_case
+    queryParameters: snake_case

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,6 @@
 # Resend's OpenAPI Spec
+[![Optic badge of documentation](https://app.useoptic.com/organizations/61d22cd6-d47c-478f-885d-677f8a89449f/public/apis/q79HOZA8RcYKFJRjSem2P/badge.svg?type=documentation&code=uTMjpUF6JtY9kmQavQ2e6.3fjas7DBSgRnJu-N3h-4BpeekyJH1Tep)](https://app.useoptic.com/organizations/61d22cd6-d47c-478f-885d-677f8a89449f/apis/q79HOZA8RcYKFJRjSem2P?ref=badge)
+
+[![Optic badge of changes](https://app.useoptic.com/organizations/61d22cd6-d47c-478f-885d-677f8a89449f/public/apis/q79HOZA8RcYKFJRjSem2P/badge.svg?type=changes&code=uTMjpUF6JtY9kmQavQ2e6.3fjas7DBSgRnJu-N3h-4BpeekyJH1Tep)](https://app.useoptic.com/organizations/61d22cd6-d47c-478f-885d-677f8a89449f/apis/q79HOZA8RcYKFJRjSem2P?ref=badge)
 
 This repository contains the [OpenAPI specification](https://www.openapis.org/) for Resend's API.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,5 @@
 # Resend's OpenAPI Spec
 [![Optic badge of documentation](https://app.useoptic.com/organizations/61d22cd6-d47c-478f-885d-677f8a89449f/public/apis/q79HOZA8RcYKFJRjSem2P/badge.svg?type=documentation&code=uTMjpUF6JtY9kmQavQ2e6.3fjas7DBSgRnJu-N3h-4BpeekyJH1Tep)](https://app.useoptic.com/organizations/61d22cd6-d47c-478f-885d-677f8a89449f/apis/q79HOZA8RcYKFJRjSem2P?ref=badge)
-
 [![Optic badge of changes](https://app.useoptic.com/organizations/61d22cd6-d47c-478f-885d-677f8a89449f/public/apis/q79HOZA8RcYKFJRjSem2P/badge.svg?type=changes&code=uTMjpUF6JtY9kmQavQ2e6.3fjas7DBSgRnJu-N3h-4BpeekyJH1Tep)](https://app.useoptic.com/organizations/61d22cd6-d47c-478f-885d-677f8a89449f/apis/q79HOZA8RcYKFJRjSem2P?ref=badge)
 
 This repository contains the [OpenAPI specification](https://www.openapis.org/) for Resend's API.


### PR DESCRIPTION
Re Twitter thread: https://twitter.com/useoptic/status/1714678854264967662

Nice work shipping your OpenAPI! This PR sets up Optic to:
- enforce consistent API design (right now it's just set up to [enforce snake_case, but can do more](https://www.useoptic.com/docs/style-guides))
- prevent breaking changes from being introduced. See [example where an enum changes ](https://app.useoptic.com/organizations/61d22cd6-d47c-478f-885d-677f8a89449f/apis/q79HOZA8RcYKFJRjSem2P/runs/eECwx7YEWbqAHpgLS8MjB)
- Render a preview of the API documentation with changes highlighted in PRs
![image](https://github.com/resendlabs/resend-openapi/assets/5900338/8ef2859f-cb46-4fd6-97b8-a27a6333d837)
- [Track historical changes](https://app.useoptic.com/organizations/61d22cd6-d47c-478f-885d-677f8a89449f/apis/q79HOZA8RcYKFJRjSem2P?specId=PBFWTj-CFqzLyBaZBzgR3&diffSpecId=ygAiI3CpR0Gc1Xd0nQwML)

If you need help ensuring that your spec remains accurate you can also check [out this workflow for verifying OpenAPI](https://github.com/opticdev/optic/blob/main/docs/generate-openapi.md)

This should be ready to merge if you [add your own `OPTIC_TOKEN`](https://app.useoptic.com) to the upstream secrets. 