### PR TITLE
feat: Update resend.yaml to support string or array for email fields

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -577,22 +577,38 @@ components:
           type: string
           description: Sender email address. To include a friendly name, use the format "Your Name <sender@domain.com>".
         to:
-          type: array
-          items:
-            type: string
-            description: Recipient email address. For multiple addresses, send as an array of strings. Max 50.
+          description: Recipient email address. For multiple addresses, send as an array of strings. Max 50.
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+              minItems: 1
+              maxItems: 50
         subject:
           type: string
           description: Email subject.
         bcc:
-          type: string
           description: Bcc recipient email address. For multiple addresses, send as an array of strings.
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
         cc:
-          type: string
           description: Cc recipient email address. For multiple addresses, send as an array of strings.
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
         reply_to:
-          type: string
           description: Reply-to email address. For multiple addresses, send as an array of strings.
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
         html:
           type: string
           description: The HTML version of the message.


### PR DESCRIPTION
This pull request updates the `resend.yaml` file to enhance the flexibility and validation of email-related fields. The changes allow fields like `to`, `bcc`, `cc`, and `reply_to` to accept either a single string or an array of strings, improving usability for different use cases.

### Enhancements to email field flexibility and validation:
* **`to` field**: Updated to accept either a single string or an array of strings, with a maximum of 50 items for arrays. Added validation for `minItems` (1) and `maxItems` (50).
* **`bcc`, `cc`, and `reply_to` fields**: Modified to support both a single string or an array of strings, aligning with the `to` field's flexibility.