### PR TITLE
fix: remove domain capabilities

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -1278,14 +1278,6 @@ components:
             - ap-northeast-1
           default: us-east-1
           description: The region where emails will be sent from. Possible values are us-east-1 | eu-west-1 | sa-east-1 | ap-northeast-1
-        capability:
-          type: string
-          enum:
-            - send
-            - receive
-            - send-and-receive
-          default: send
-          description: The capability of the domain. Determines which DNS records are needed.
     CreateDomainResponse:
       type: object
       properties:
@@ -1309,13 +1301,6 @@ components:
         region:
           type: string
           description: The region where the domain is hosted.
-        capability:
-          type: string
-          enum:
-            - send
-            - receive
-            - send-and-receive
-          description: The capability of the domain.
     UpdateDomainOptions:
       type: object
       properties:
@@ -1395,14 +1380,6 @@ components:
           type: string
           description: The region where the domain is hosted.
           example: 'us-east-1'
-        capability:
-          type: string
-          enum:
-            - send
-            - receive
-            - send-and-receive
-          description: The capability of the domain.
-          example: 'send'
         records:
           type: array
           items:
@@ -1449,14 +1426,6 @@ components:
           type: string
           description: The region where the domain is hosted.
           example: 'us-east-1'
-        capability:
-          type: string
-          enum:
-            - send
-            - receive
-            - send-and-receive
-          description: The capability of the domain.
-          example: 'send'
     UpdateDomainResponseSuccess:
       type: object
       properties:


### PR DESCRIPTION
We removed capabilities from the domains API, so removing it from here too for consistency.