### PR TITLE
feat: update with last release endpoints

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -1694,22 +1694,6 @@ components:
           type: string
           description: The status of the email.
           example: 'delivered'
-    ListEmailsResponse:
-      type: object
-      properties:
-        object:
-          type: string
-          description: Type of the response object.
-          example: 'list'
-        has_more:
-          type: boolean
-          description: Indicates if there are more results available.
-          example: false
-        data:
-          type: array
-          description: Array containing email information.
-          items:
-            $ref: '#/components/schemas/Email'
     CreateBatchEmailsResponse:
       type: object
       properties:
@@ -2347,49 +2331,6 @@ components:
           nullable: true
           description: The HTML version of the broadcast content.
           example: '<p>Hello {{{FIRST_NAME|there}}}!</p>'
-    UpdateBroadcastOptions:
-      type: object
-      properties:
-        name:
-          type: string
-          description: Name of the broadcast.
-        audience_id:
-          type: string
-          description: Unique identifier of the audience this broadcast will be sent to.
-        segment_id:
-          type: string
-          description: Unique identifier of the segment this broadcast will be sent to.
-        from:
-          type: string
-          description: The email address of the sender.
-        subject:
-          type: string
-          description: The subject line of the email.
-        reply_to:
-          type: array
-          items:
-            type: string
-          description: The email addresses to which replies should be sent.
-        preview_text:
-          type: string
-          description: The preview text of the email.
-        html:
-          type: string
-          description: The HTML version of the message.
-        text:
-          type: string
-          description: The plain text version of the message.
-    UpdateBroadcastResponseSuccess:
-      type: object
-      properties:
-        id:
-          type: string
-          description: The ID of the broadcast.
-          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
-        object:
-          type: string
-          description: The object type of the response.
-          example: broadcast
     RemoveBroadcastResponseSuccess:
       type: object
       properties:
@@ -3594,3 +3535,62 @@ components:
               subscribed:
                 type: boolean
                 description: The subscription status.
+    ListEmailsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: 'list'
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+          example: false
+        data:
+          type: array
+          description: Array containing email information.
+          items:
+            $ref: '#/components/schemas/Email'
+    UpdateBroadcastOptions:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the broadcast.
+        audience_id:
+          type: string
+          description: Unique identifier of the audience this broadcast will be sent to.
+        segment_id:
+          type: string
+          description: Unique identifier of the segment this broadcast will be sent to.
+        from:
+          type: string
+          description: The email address of the sender.
+        subject:
+          type: string
+          description: The subject line of the email.
+        reply_to:
+          type: array
+          items:
+            type: string
+          description: The email addresses to which replies should be sent.
+        preview_text:
+          type: string
+          description: The preview text of the email.
+        html:
+          type: string
+          description: The HTML version of the message.
+        text:
+          type: string
+          description: The plain text version of the message.
+    UpdateBroadcastResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the broadcast.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type of the response.
+          example: broadcast

--- a/resend.yaml
+++ b/resend.yaml
@@ -1694,6 +1694,22 @@ components:
           type: string
           description: The status of the email.
           example: 'delivered'
+    ListEmailsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: 'list'
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+          example: false
+        data:
+          type: array
+          description: Array containing email information.
+          items:
+            $ref: '#/components/schemas/Email'
     CreateBatchEmailsResponse:
       type: object
       properties:
@@ -2331,6 +2347,49 @@ components:
           nullable: true
           description: The HTML version of the broadcast content.
           example: '<p>Hello {{{FIRST_NAME|there}}}!</p>'
+    UpdateBroadcastOptions:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the broadcast.
+        audience_id:
+          type: string
+          description: Unique identifier of the audience this broadcast will be sent to.
+        segment_id:
+          type: string
+          description: Unique identifier of the segment this broadcast will be sent to.
+        from:
+          type: string
+          description: The email address of the sender.
+        subject:
+          type: string
+          description: The subject line of the email.
+        reply_to:
+          type: array
+          items:
+            type: string
+          description: The email addresses to which replies should be sent.
+        preview_text:
+          type: string
+          description: The preview text of the email.
+        html:
+          type: string
+          description: The HTML version of the message.
+        text:
+          type: string
+          description: The plain text version of the message.
+    UpdateBroadcastResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the broadcast.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type of the response.
+          example: broadcast
     RemoveBroadcastResponseSuccess:
       type: object
       properties:
@@ -3535,62 +3594,3 @@ components:
               subscribed:
                 type: boolean
                 description: The subscription status.
-    ListEmailsResponse:
-      type: object
-      properties:
-        object:
-          type: string
-          description: Type of the response object.
-          example: 'list'
-        has_more:
-          type: boolean
-          description: Indicates if there are more results available.
-          example: false
-        data:
-          type: array
-          description: Array containing email information.
-          items:
-            $ref: '#/components/schemas/Email'
-    UpdateBroadcastOptions:
-      type: object
-      properties:
-        name:
-          type: string
-          description: Name of the broadcast.
-        audience_id:
-          type: string
-          description: Unique identifier of the audience this broadcast will be sent to.
-        segment_id:
-          type: string
-          description: Unique identifier of the segment this broadcast will be sent to.
-        from:
-          type: string
-          description: The email address of the sender.
-        subject:
-          type: string
-          description: The subject line of the email.
-        reply_to:
-          type: array
-          items:
-            type: string
-          description: The email addresses to which replies should be sent.
-        preview_text:
-          type: string
-          description: The preview text of the email.
-        html:
-          type: string
-          description: The HTML version of the message.
-        text:
-          type: string
-          description: The plain text version of the message.
-    UpdateBroadcastResponseSuccess:
-      type: object
-      properties:
-        id:
-          type: string
-          description: The ID of the broadcast.
-          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
-        object:
-          type: string
-          description: The object type of the response.
-          example: broadcast

--- a/resend.yaml
+++ b/resend.yaml
@@ -24,6 +24,14 @@ tags:
     description: Create and manage Webhooks through the Resend API.
   - name: Templates
     description: Create and manage Templates through the Resend API.
+  - name: Broadcasts
+    description: Create and manage Broadcasts through the Resend API.
+  - name: Segments
+    description: Create and manage Segments through the Resend API.
+  - name: Topics
+    description: Create and manage Topics through the Resend API.
+  - name: Contact Properties
+    description: Create and manage Contact Properties through the Resend API.
 paths:
   /emails:
     post:
@@ -50,6 +58,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SendEmailResponse'
+    get:
+      tags:
+        - Emails
+      summary: Retrieve a list of emails
+      parameters:
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationAfter'
+        - $ref: '#/components/parameters/PaginationBefore'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListEmailsResponse'
   /emails/{email_id}:
     get:
       tags:
@@ -923,6 +946,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetBroadcastResponseSuccess'
+    patch:
+      tags:
+        - Broadcasts
+      summary: Update an existing broadcast
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Broadcast ID.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateBroadcastOptions'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateBroadcastResponseSuccess'
   /broadcasts/{id}/send:
     post:
       tags:
@@ -1059,6 +1105,404 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteWebhookResponse'
+  /segments:
+    post:
+      tags:
+        - Segments
+      summary: Create a new segment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSegmentOptions'
+      responses:
+        '201':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateSegmentResponseSuccess'
+    get:
+      tags:
+        - Segments
+      summary: Retrieve a list of segments
+      parameters:
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationAfter'
+        - $ref: '#/components/parameters/PaginationBefore'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSegmentsResponseSuccess'
+  /segments/{id}:
+    get:
+      tags:
+        - Segments
+      summary: Retrieve a single segment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Segment ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSegmentResponseSuccess'
+    delete:
+      tags:
+        - Segments
+      summary: Remove an existing segment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Segment ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoveSegmentResponseSuccess'
+  /topics:
+    post:
+      tags:
+        - Topics
+      summary: Create a new topic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTopicOptions'
+      responses:
+        '201':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateTopicResponseSuccess'
+    get:
+      tags:
+        - Topics
+      summary: Retrieve a list of topics
+      parameters:
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationAfter'
+        - $ref: '#/components/parameters/PaginationBefore'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListTopicsResponseSuccess'
+  /topics/{id}:
+    get:
+      tags:
+        - Topics
+      summary: Retrieve a single topic
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Topic ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTopicResponseSuccess'
+    patch:
+      tags:
+        - Topics
+      summary: Update an existing topic
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Topic ID.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTopicOptions'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateTopicResponseSuccess'
+    delete:
+      tags:
+        - Topics
+      summary: Remove an existing topic
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Topic ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoveTopicResponseSuccess'
+  /contact-properties:
+    post:
+      tags:
+        - Contact Properties
+      summary: Create a new contact property
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateContactPropertyOptions'
+      responses:
+        '201':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateContactPropertyResponseSuccess'
+    get:
+      tags:
+        - Contact Properties
+      summary: Retrieve a list of contact properties
+      parameters:
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationAfter'
+        - $ref: '#/components/parameters/PaginationBefore'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListContactPropertiesResponseSuccess'
+  /contact-properties/{id}:
+    get:
+      tags:
+        - Contact Properties
+      summary: Retrieve a single contact property
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Contact Property ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetContactPropertyResponseSuccess'
+    patch:
+      tags:
+        - Contact Properties
+      summary: Update an existing contact property
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Contact Property ID.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateContactPropertyOptions'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateContactPropertyResponseSuccess'
+    delete:
+      tags:
+        - Contact Properties
+      summary: Remove an existing contact property
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Contact Property ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoveContactPropertyResponseSuccess'
+  /audiences/{audience_id}/contacts/{id}/segments:
+    post:
+      tags:
+        - Contacts
+      summary: Add a contact to a segment
+      parameters:
+        - name: audience_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Audience ID.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Contact ID.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddContactToSegmentOptions'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddContactToSegmentResponseSuccess'
+    get:
+      tags:
+        - Contacts
+      summary: Retrieve a list of segments for a contact
+      parameters:
+        - name: audience_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Audience ID.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Contact ID.
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationAfter'
+        - $ref: '#/components/parameters/PaginationBefore'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListContactSegmentsResponseSuccess'
+  /audiences/{audience_id}/contacts/{id}/segments/{segment_id}:
+    delete:
+      tags:
+        - Contacts
+      summary: Remove a contact from a segment
+      parameters:
+        - name: audience_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Audience ID.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Contact ID.
+        - name: segment_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Segment ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoveContactFromSegmentResponseSuccess'
+  /audiences/{audience_id}/contacts/{id}/topics:
+    get:
+      tags:
+        - Contacts
+      summary: Retrieve topics for a contact
+      parameters:
+        - name: audience_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Audience ID.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Contact ID.
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationAfter'
+        - $ref: '#/components/parameters/PaginationBefore'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetContactTopicsResponseSuccess'
+    patch:
+      tags:
+        - Contacts
+      summary: Update topics for a contact
+      parameters:
+        - name: audience_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Audience ID.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Contact ID.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateContactTopicsOptions'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateContactTopicsResponseSuccess'
 components:
   securitySchemes:
     bearerAuth:
@@ -1250,6 +1694,22 @@ components:
           type: string
           description: The status of the email.
           example: 'delivered'
+    ListEmailsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: 'list'
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+          example: false
+        data:
+          type: array
+          description: Array containing email information.
+          items:
+            $ref: '#/components/schemas/Email'
     CreateBatchEmailsResponse:
       type: object
       properties:
@@ -1887,6 +2347,49 @@ components:
           nullable: true
           description: The HTML version of the broadcast content.
           example: '<p>Hello {{{FIRST_NAME|there}}}!</p>'
+    UpdateBroadcastOptions:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the broadcast.
+        audience_id:
+          type: string
+          description: Unique identifier of the audience this broadcast will be sent to.
+        segment_id:
+          type: string
+          description: Unique identifier of the segment this broadcast will be sent to.
+        from:
+          type: string
+          description: The email address of the sender.
+        subject:
+          type: string
+          description: The subject line of the email.
+        reply_to:
+          type: array
+          items:
+            type: string
+          description: The email addresses to which replies should be sent.
+        preview_text:
+          type: string
+          description: The preview text of the email.
+        html:
+          type: string
+          description: The HTML version of the message.
+        text:
+          type: string
+          description: The plain text version of the message.
+    UpdateBroadcastResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the broadcast.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type of the response.
+          example: broadcast
     RemoveBroadcastResponseSuccess:
       type: object
       properties:
@@ -2639,3 +3142,455 @@ components:
           type: string
           description: The object type of the response.
           example: template
+    CreateSegmentOptions:
+      type: object
+      required:
+        - name
+        - audience_id
+      properties:
+        name:
+          type: string
+          description: The name of the segment.
+        audience_id:
+          type: string
+          description: The ID of the audience this segment belongs to.
+        filter:
+          type: object
+          description: Filter conditions for the segment.
+    CreateSegmentResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the segment.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type of the response.
+          example: segment
+    GetSegmentResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the segment.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type.
+          example: segment
+        name:
+          type: string
+          description: The name of the segment.
+          example: Active Users
+        audience_id:
+          type: string
+          description: The ID of the audience this segment belongs to.
+        filter:
+          type: object
+          description: Filter conditions for the segment.
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp indicating when the segment was created.
+    ListSegmentsResponseSuccess:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: list
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+        data:
+          type: array
+          description: Array containing segment information.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Unique identifier for the segment.
+              name:
+                type: string
+                description: Name of the segment.
+              audience_id:
+                type: string
+                description: The ID of the audience this segment belongs to.
+              created_at:
+                type: string
+                format: date-time
+                description: Timestamp indicating when the segment was created.
+    RemoveSegmentResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the segment.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type.
+          example: segment
+        deleted:
+          type: boolean
+          description: Indicates whether the segment was successfully deleted.
+          example: true
+    CreateTopicOptions:
+      type: object
+      required:
+        - name
+        - audience_id
+      properties:
+        name:
+          type: string
+          description: The name of the topic.
+        audience_id:
+          type: string
+          description: The ID of the audience this topic belongs to.
+    CreateTopicResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the topic.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type of the response.
+          example: topic
+    GetTopicResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the topic.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type.
+          example: topic
+        name:
+          type: string
+          description: The name of the topic.
+          example: Newsletter
+        audience_id:
+          type: string
+          description: The ID of the audience this topic belongs to.
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp indicating when the topic was created.
+    ListTopicsResponseSuccess:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: list
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+        data:
+          type: array
+          description: Array containing topic information.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Unique identifier for the topic.
+              name:
+                type: string
+                description: Name of the topic.
+              audience_id:
+                type: string
+                description: The ID of the audience this topic belongs to.
+              created_at:
+                type: string
+                format: date-time
+                description: Timestamp indicating when the topic was created.
+    UpdateTopicOptions:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the topic.
+    UpdateTopicResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the topic.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type.
+          example: topic
+    RemoveTopicResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the topic.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type.
+          example: topic
+        deleted:
+          type: boolean
+          description: Indicates whether the topic was successfully deleted.
+          example: true
+    CreateContactPropertyOptions:
+      type: object
+      required:
+        - name
+        - type
+      properties:
+        name:
+          type: string
+          description: The name of the contact property.
+        type:
+          type: string
+          enum:
+            - string
+            - number
+            - boolean
+            - date
+          description: The type of the contact property.
+        description:
+          type: string
+          description: A description of the contact property.
+    CreateContactPropertyResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the contact property.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type of the response.
+          example: contact_property
+    GetContactPropertyResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the contact property.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type.
+          example: contact_property
+        name:
+          type: string
+          description: The name of the contact property.
+          example: company_size
+        type:
+          type: string
+          description: The type of the contact property.
+          example: number
+        description:
+          type: string
+          description: A description of the contact property.
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp indicating when the contact property was created.
+    ListContactPropertiesResponseSuccess:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: list
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+        data:
+          type: array
+          description: Array containing contact property information.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Unique identifier for the contact property.
+              name:
+                type: string
+                description: Name of the contact property.
+              type:
+                type: string
+                description: The type of the contact property.
+              description:
+                type: string
+                description: A description of the contact property.
+              created_at:
+                type: string
+                format: date-time
+                description: Timestamp indicating when the contact property was created.
+    UpdateContactPropertyOptions:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the contact property.
+        description:
+          type: string
+          description: A description of the contact property.
+    UpdateContactPropertyResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the contact property.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type.
+          example: contact_property
+    RemoveContactPropertyResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the contact property.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type.
+          example: contact_property
+        deleted:
+          type: boolean
+          description: Indicates whether the contact property was successfully deleted.
+          example: true
+    AddContactToSegmentOptions:
+      type: object
+      required:
+        - segment_id
+      properties:
+        segment_id:
+          type: string
+          description: The ID of the segment to add the contact to.
+    AddContactToSegmentResponseSuccess:
+      type: object
+      properties:
+        object:
+          type: string
+          description: The object type.
+          example: contact_segment
+        contact_id:
+          type: string
+          description: The ID of the contact.
+        segment_id:
+          type: string
+          description: The ID of the segment.
+    ListContactSegmentsResponseSuccess:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: list
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+        data:
+          type: array
+          description: Array containing segment information for this contact.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Unique identifier for the segment.
+              name:
+                type: string
+                description: Name of the segment.
+              created_at:
+                type: string
+                format: date-time
+                description: Timestamp indicating when the contact was added to the segment.
+    RemoveContactFromSegmentResponseSuccess:
+      type: object
+      properties:
+        object:
+          type: string
+          description: The object type.
+          example: contact_segment
+        contact_id:
+          type: string
+          description: The ID of the contact.
+        segment_id:
+          type: string
+          description: The ID of the segment.
+        deleted:
+          type: boolean
+          description: Indicates whether the contact was successfully removed from the segment.
+          example: true
+    GetContactTopicsResponseSuccess:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: list
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+        data:
+          type: array
+          description: Array containing topic subscriptions for this contact.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Unique identifier for the topic.
+              name:
+                type: string
+                description: Name of the topic.
+              subscribed:
+                type: boolean
+                description: Indicates if the contact is subscribed to this topic.
+    UpdateContactTopicsOptions:
+      type: object
+      required:
+        - topics
+      properties:
+        topics:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: The ID of the topic.
+              subscribed:
+                type: boolean
+                description: Whether to subscribe or unsubscribe from the topic.
+    UpdateContactTopicsResponseSuccess:
+      type: object
+      properties:
+        object:
+          type: string
+          description: The object type.
+          example: contact_topics
+        contact_id:
+          type: string
+          description: The ID of the contact.
+        topics:
+          type: array
+          description: Array of updated topic subscriptions.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: The ID of the topic.
+              subscribed:
+                type: boolean
+                description: The subscription status.


### PR DESCRIPTION
## Missing Endpoints in the Spec

### Emails
1. **List Sent Emails**  
   `GET /emails`  
   The official docs include a “List Sent Emails” endpoint that is not present in the current spec.

### Broadcasts
1. **Update Broadcast**  
   `PATCH /broadcasts/{id}`  
   This endpoint exists in the docs but is missing from the spec.

### Segments
1. **Create Segment**  
   `POST /segments`

2. **Retrieve Segment**  
   `GET /segments/{id}`

3. **List Segments**  
   `GET /segments`

4. **Delete Segment**  
   `DELETE /segments/{id}`

### Contact Segments
1. **Add Contact to Segment**  
   `POST`

2. **List Contact Segments**  
   `GET`

3. **Delete Contact Segment**  
   `DELETE`

### Contact Topics
1. **Retrieve Contact Topics**  
   `GET`

2. **Update Contact Topics**  
   `PATCH`

### Contact Properties
1. **Create Contact Property**  
   `POST`

2. **Retrieve Contact Property**  
   `GET`

3. **List Contact Properties**  
   `GET`

4. **Update Contact Property**  
   `PATCH`

5. **Delete Contact Property**  
   `DELETE`

### Topics
1. **Create Topic**  
   `POST`

2. **Retrieve Topic**  
   `GET`

3. **List Topics**  
   `GET`

4. **Update Topic**  
   `PATCH`

5. **Delete Topic**  
   `DELETE`
