### PR TITLE
spec(resend-openapi): add last_used_at to ApiKey schema

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -1935,6 +1935,11 @@ components:
           type: string
           format: date-time
           description: The date and time the API key was created.
+        last_used_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: The date and time the API key was last used.
     CreateAudienceOptions:
       type: object
       deprecated: true


### PR DESCRIPTION
## Summary

Added a nullable `last_used_at` field to the ApiKey schema in the OpenAPI spec. This field tracks when an API key was last used and follows the same `date-time` format as other timestamp fields like `created_at`. The field is nullable to handle keys that have never been used.

## Testing steps

- [ ] Verify the YAML is valid by checking syntax in the editor or running a YAML linter
- [ ] Confirm the `last_used_at` field appears in the GET /api-keys endpoint response schema
- [ ] Check that the field type matches other date-time fields (string, format: date-time, nullable: true)