### PR TITLE
feat: add json build script for openapi spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+resend.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "resend-openapi",
+  "version": "1.5.0",
+  "private": true,
+  "description": "OpenAPI specification for Resend's API",
+  "scripts": {
+    "build": "node scripts/build-json.mjs",
+    "build:yaml": "node scripts/build-json.mjs"
+  },
+  "devDependencies": {
+    "yaml": "^2.7.1"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      yaml:
+        specifier: ^2.7.1
+        version: 2.8.3
+
+packages:
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+snapshots:
+
+  yaml@2.8.3: {}

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,14 @@
 # Resend's OpenAPI Spec
 
 This repository contains the [OpenAPI specification](https://www.openapis.org/) for Resend's API.
+
+## Build
+
+Generate the JSON version of the spec:
+
+```sh
+pnpm install
+pnpm build
+```
+
+This outputs `resend.json` from `resend.yaml`.

--- a/scripts/build-json.mjs
+++ b/scripts/build-json.mjs
@@ -1,0 +1,17 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+
+const yamlPath = join(root, "resend.yaml");
+const jsonPath = join(root, "resend.json");
+
+const yamlContent = readFileSync(yamlPath, "utf8");
+const spec = parse(yamlContent);
+
+writeFileSync(jsonPath, JSON.stringify(spec, null, 2) + "\n");
+
+console.log(`✓ Generated ${jsonPath}`);


### PR DESCRIPTION
Adds a build script that generates `resend.json` from `resend.yaml`.

## What

- `scripts/build-json.mjs` — converts the YAML OpenAPI spec to JSON
- `package.json` with `pnpm build` command
- `.gitignore` to exclude the generated `resend.json` and `node_modules`
- Updated `readme.md` with build instructions

## Usage

```sh
pnpm install
pnpm build
```

Outputs `resend.json` from `resend.yaml`.

---

Requested by Zeno in [#proj-hermes](https://resend.slack.com/archives/C0AF99AFEAJ/p1774828120508849)