### PR TITLE
fix: template syntax

### DIFF
--- a/resend.json
+++ b/resend.json
@@ -6290,7 +6290,7 @@
           },
           "config": {
             "type": "object",
-            "description": "Configuration for the step. Shape depends on `type`: - **trigger**: `{ event_name: string }` - **send_email**: `{ template_id: string, subject?: string, from?: string, reply_to?: string, variables?: object }` - **delay**: `{ seconds: number }` - **wait_for_event**: `{ event_name: string, timeout?: string, filter_rule?: object }` - **condition**: A rule tree with `type` (`rule`, `and`, `or`), `field`, `operator`, and `value` - **contact_update**: `{ first_name?: string|object, last_name?: string|object, unsubscribed?: boolean|object, properties?: object }` - **contact_delete**: `{}` - **add_to_segment**: `{ segment_id: string }`\n"
+            "description": "Configuration for the step. Shape depends on `type`: - **trigger**: `{ event_name: string }` - **send_email**: `{ template: { id: string, variables?: object }, subject?: string, from?: string, reply_to?: string }` - **delay**: `{ seconds: number }` - **wait_for_event**: `{ event_name: string, timeout?: string, filter_rule?: object }` - **condition**: A rule tree with `type` (`rule`, `and`, `or`), `field`, `operator`, and `value` - **contact_update**: `{ first_name?: string|object, last_name?: string|object, unsubscribed?: boolean|object, properties?: object }` - **contact_delete**: `{}` - **add_to_segment**: `{ segment_id: string }`\n"
           }
         }
       },

--- a/resend.json
+++ b/resend.json
@@ -6265,14 +6265,14 @@
         "type": "object",
         "description": "A step in an automation workflow. The `config` object varies based on the step `type`.",
         "required": [
-          "ref",
+          "key",
           "type",
           "config"
         ],
         "properties": {
-          "ref": {
+          "key": {
             "type": "string",
-            "description": "A unique reference identifier for this step within the automation graph."
+            "description": "A unique key for this step within the automation graph."
           },
           "type": {
             "type": "string",
@@ -6290,7 +6290,7 @@
           },
           "config": {
             "type": "object",
-            "description": "Configuration for the step. Shape depends on `type`: - **trigger**: `{ event_name: string }` - **send_email**: `{ template: { id: string, variables?: object }, subject?: string, from?: string, reply_to?: string }` - **delay**: `{ seconds: number }` - **wait_for_event**: `{ event_name: string, timeout?: string, filter_rule?: object }` - **condition**: A rule tree with `type` (`rule`, `and`, `or`), `field`, `operator`, and `value` - **contact_update**: `{ first_name?: string|object, last_name?: string|object, unsubscribed?: boolean|object, properties?: object }` - **contact_delete**: `{}` - **add_to_segment**: `{ segment_id: string }`\n"
+            "description": "Configuration for the step. Shape depends on `type`: - **trigger**: `{ event_name: string }` - **send_email**: `{ template: { id: string, variables?: object }, subject?: string, from?: string, reply_to?: string }` - **delay**: `{ duration?: string, seconds?: number }` — provide exactly one of `duration` (e.g. `\"30 minutes\"`) or `seconds` - **wait_for_event**: `{ event_name: string, timeout?: string, filter_rule?: object }` — `timeout` is a human-readable duration (e.g. `\"1 hour\"`) - **condition**: A rule tree with `type` (`rule`, `and`, `or`), `field`, `operator`, and `value` - **contact_update**: `{ first_name?: string|object, last_name?: string|object, unsubscribed?: boolean|object, properties?: object }` - **contact_delete**: `{}` - **add_to_segment**: `{ segment_id: string }`\n"
           }
         }
       },
@@ -6298,6 +6298,10 @@
         "type": "object",
         "description": "A step as returned when retrieving an automation.",
         "properties": {
+          "key": {
+            "type": "string",
+            "description": "The unique key of this step within the automation graph."
+          },
           "type": {
             "type": "string",
             "enum": [
@@ -6314,13 +6318,13 @@
           },
           "config": {
             "type": "object",
-            "description": "Configuration for the step. Shape depends on `type`."
+            "description": "Configuration for the step. Shape depends on `type`. For `delay` steps, config contains `{ duration: string }` with a human-readable duration (e.g. `\"30 minutes\"`). For `wait_for_event` steps, config contains `{ event_name: string, timeout?: string, filter_rule?: object }` where `timeout` is a human-readable duration.\n"
           }
         }
       },
-      "AutomationEdge": {
+      "AutomationConnection": {
         "type": "object",
-        "description": "An edge connecting two steps in the automation graph.",
+        "description": "A connection between two steps in the automation graph.",
         "required": [
           "from",
           "to"
@@ -6328,13 +6332,13 @@
         "properties": {
           "from": {
             "type": "string",
-            "description": "The `ref` of the source step (in requests) or the step ID (in responses)."
+            "description": "The `key` of the source step."
           },
           "to": {
             "type": "string",
-            "description": "The `ref` of the target step (in requests) or the step ID (in responses)."
+            "description": "The `key` of the target step."
           },
-          "edge_type": {
+          "type": {
             "type": "string",
             "enum": [
               "default",
@@ -6344,7 +6348,7 @@
               "event_received"
             ],
             "default": "default",
-            "description": "The type of edge. Defaults to `default`."
+            "description": "The type of connection. Defaults to `default`."
           }
         }
       },
@@ -6353,7 +6357,7 @@
         "required": [
           "name",
           "steps",
-          "edges"
+          "connections"
         ],
         "properties": {
           "name": {
@@ -6379,11 +6383,11 @@
               "$ref": "#/components/schemas/AutomationStep"
             }
           },
-          "edges": {
+          "connections": {
             "type": "array",
-            "description": "The edges connecting steps in the automation graph.",
+            "description": "The connections between steps in the automation graph.",
             "items": {
-              "$ref": "#/components/schemas/AutomationEdge"
+              "$ref": "#/components/schemas/AutomationConnection"
             }
           }
         }
@@ -6441,11 +6445,11 @@
               "$ref": "#/components/schemas/AutomationStepResponse"
             }
           },
-          "edges": {
+          "connections": {
             "type": "array",
-            "description": "The edges connecting steps in the active version of the automation.",
+            "description": "The connections between steps in the active version of the automation.",
             "items": {
-              "$ref": "#/components/schemas/AutomationEdge"
+              "$ref": "#/components/schemas/AutomationConnection"
             }
           }
         }
@@ -6502,7 +6506,7 @@
       },
       "PatchAutomationRequest": {
         "type": "object",
-        "description": "At least one of `name`, `status`, or `steps` and `edges` must be provided. When updating the workflow graph, both `steps` and `edges` must be provided together.\n",
+        "description": "At least one of `name`, `status`, or `steps` and `connections` must be provided. When updating the workflow graph, both `steps` and `connections` must be provided together.\n",
         "properties": {
           "name": {
             "type": "string",
@@ -6521,16 +6525,16 @@
             "type": "array",
             "minItems": 1,
             "maxItems": 150,
-            "description": "The steps that compose the automation workflow. Must be provided together with `edges`.",
+            "description": "The steps that compose the automation workflow. Must be provided together with `connections`.",
             "items": {
               "$ref": "#/components/schemas/AutomationStep"
             }
           },
-          "edges": {
+          "connections": {
             "type": "array",
-            "description": "The edges connecting steps in the automation graph. Must be provided together with `steps`.",
+            "description": "The connections between steps in the automation graph. Must be provided together with `steps`.",
             "items": {
-              "$ref": "#/components/schemas/AutomationEdge"
+              "$ref": "#/components/schemas/AutomationConnection"
             }
           }
         }
@@ -6591,6 +6595,10 @@
         "type": "object",
         "description": "A step execution within an automation run.",
         "properties": {
+          "key": {
+            "type": "string",
+            "description": "The key of the automation step."
+          },
           "type": {
             "type": "string",
             "enum": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- Revert unintended change in `resend.json` per review feedback.
- Keep the template config syntax update only in `resend.yaml`.

No other changes were made.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac1382bc-7508-4a4f-a83a-98298da361a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac1382bc-7508-4a4f-a83a-98298da361a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

