### PR TITLE
feat(domains): add TrackingCAA record type

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -2092,7 +2092,8 @@ components:
             - DKIM
             - Receiving
             - Tracking
-          description: The type of record (SPF for sending, DKIM for sending, Receiving for inbound emails, Tracking for click and open tracking).
+            - TrackingCAA
+          description: The type of record (SPF for sending, DKIM for sending, Receiving for inbound emails, Tracking for click and open tracking, TrackingCAA for the CAA record required when the root domain has CAA records that would block AWS from issuing a certificate for the tracking subdomain).
         name:
           type: string
           description: The name of the DNS record.
@@ -2102,6 +2103,7 @@ components:
             - MX
             - TXT
             - CNAME
+            - CAA
           description: The DNS record type.
         ttl:
           type: string

--- a/resend.yaml
+++ b/resend.yaml
@@ -2093,7 +2093,7 @@ components:
             - Receiving
             - Tracking
             - TrackingCAA
-          description: The type of record (SPF for sending, DKIM for sending, Receiving for inbound emails, Tracking for click and open tracking, TrackingCAA for the CAA record required when the root domain has CAA records that would block AWS from issuing a certificate for the tracking subdomain).
+          description: The type of record (SPF for sending, DKIM for sending, Receiving for inbound emails, Tracking & TrackingCAA for click and open tracking).
         name:
           type: string
           description: The name of the DNS record.


### PR DESCRIPTION
## Summary

The Domains API now returns an additional DNS record on `POST /domains` and `GET /domains/:id` responses when:

1. A `tracking_subdomain` is configured on the domain, AND
2. The customer's root domain has CAA records that would otherwise prevent AWS from issuing a TLS certificate for the tracking subdomain.

The new record looks like:

```json
{
  "record": "TrackingCAA",
  "name": "",
  "type": "CAA",
  "ttl": "Auto",
  "value": "0 issue \"amazon.com\"",
  "status": "verified"
}
```

This PR updates `DomainRecord` in `resend.yaml`:

- Adds `TrackingCAA` to the `record` enum.
- Adds `CAA` to the `type` enum.
- Extends the `record` description to cover when a `TrackingCAA` record is emitted.

`resend.json` is auto-generated from `resend.yaml` on push to main, so it's not edited here.

## Test plan

- [x] YAML lint / openapi validators (CI)