### PR TITLE
fix: add new domain statuses

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -2045,6 +2045,13 @@ components:
           description: The date and time the domain was created.
         status:
           type: string
+          enum:
+            - pending
+            - verified
+            - failed
+            - not_started
+            - partially_verified
+            - partially_failed
           description: The status of the domain.
         capabilities:
           $ref: '#/components/schemas/DomainCapabilities'
@@ -2140,6 +2147,13 @@ components:
           example: 'example.com'
         status:
           type: string
+          enum:
+            - pending
+            - verified
+            - failed
+            - not_started
+            - partially_verified
+            - partially_failed
           description: The status of the domain.
           example: 'not_started'
         created_at:
@@ -2205,6 +2219,13 @@ components:
           example: 'example.com'
         status:
           type: string
+          enum:
+            - pending
+            - verified
+            - failed
+            - not_started
+            - partially_verified
+            - partially_failed
           description: The status of the domain.
           example: 'not_started'
         created_at:


### PR DESCRIPTION
## Summary

Add `partially_verified` and `partially_failed` to the domain-level `status` enum across `CreateDomainResponse`, `Domain`, and `ListDomainsItem` schemas.

Previously `Domain.status` was an unconstrained `type: string`. This change adds an explicit enum listing all 7 valid domain-level statuses.

`DomainRecord.status` is intentionally unchanged — these new values apply only at the domain level, not to individual DNS records.

Matches resend/resend-node#936.

## Valid domain statuses

- `pending`
- `verified`
- `failed`
- `not_started`
- `partially_verified` *(new)*
- `partially_failed` *(new)*