### PR TITLE
fix: declare type for nullable jsonb fields in Log and AutomationRunStep

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -4191,9 +4191,11 @@ components:
           nullable: true
           description: The user agent of the request.
         request_body:
+          type: object
           nullable: true
           description: The request body sent to the API.
         response_body:
+          type: object
           nullable: true
           description: The response body returned by the API.
     ListLogsResponse:
@@ -4503,9 +4505,11 @@ components:
           nullable: true
           description: The date and time the step completed executing.
         output:
+          type: object
           nullable: true
           description: The output produced by the step, if any.
         error:
+          type: object
           nullable: true
           description: The error produced by the step, if any.
         created_at:


### PR DESCRIPTION
Four fields (Log.request_body, Log.response_body, AutomationRunStep.output, AutomationRunStep.error) had `nullable: true` without a `type` declaration, which is invalid OpenAPI 3.0 - `nullable` requires a type to apply to.

All four are backed by Postgres jsonb columns and surface as JSON objects when present, null otherwise (verified against the monorepo). Adding `type: object` makes the spec accurate without overcommitting to the inner shape of step outputs/errors.

Validated with `redocly lint`: strict errors drop from 4 to 0; warnings unchanged.