### PR TITLE
chore: harden generate-json workflow

### DIFF
--- a/.github/workflows/generate-json.yml
+++ b/.github/workflows/generate-json.yml
@@ -5,14 +5,17 @@ on:
     branches: [main]
     paths: [resend.yaml]
 
+permissions: {}
+
 jobs:
   generate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Convert YAML to JSON
         run: yq -o=json resend.yaml > resend.json
@@ -24,7 +27,7 @@ jobs:
 
       - name: Create PR
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           commit-message: 'chore: update resend.json'
           title: 'chore: update resend.json'


### PR DESCRIPTION
- pin peter-evans/create-pull-request and actions/checkout to SHAs
- add deny-by-default top-level permissions
- add timeout-minutes to generate job