### PR TITLE
fix: remove contact import on_error option

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -2965,14 +2965,6 @@ components:
           default: skip
           description: Strategy to use when an imported contact already exists.
           example: skip
-        on_error:
-          type: string
-          enum:
-            - continue
-            - abort
-          default: continue
-          description: Strategy to use when an imported row fails validation.
-          example: continue
         segments:
           type: string
           description: JSON-encoded array of segments to add imported contacts to.


### PR DESCRIPTION
## Summary
- Remove the unsupported `on_error` option from the contact import request schema.
- Keep the contact import multipart form schema limited to the remaining supported fields.

## Test plan
- Parsed `resend.yaml` with Ruby YAML loader.
- Searched the repo to confirm `on_error` no longer appears.
- Checked editor diagnostics for `resend.yaml`.

Made with [Cursor](https://cursor.com)