### PR TITLE
feat: add message_id to Email schema

### DIFF
--- a/resend.json
+++ b/resend.json
@@ -3153,7 +3153,7 @@
           "message_id": {
             "type": "string",
             "description": "The Message-ID header value of the email.",
-            "example": "<202301010000.4ef9a417@resend.dev>"
+            "example": "<202301010000.4ef9a417@email.example.com>"
           },
           "to": {
             "type": "array",
@@ -4634,7 +4634,7 @@
           "message_id": {
             "type": "string",
             "description": "The unique message ID from the email headers.",
-            "example": "<message-id@example.com>"
+            "example": "<message-id@email.example.com>"
           },
           "bcc": {
             "type": [
@@ -4792,7 +4792,7 @@
                 "message_id": {
                   "type": "string",
                   "description": "The unique message ID from the email headers.",
-                  "example": "<message-id@example.com>"
+                  "example": "<message-id@email.example.com>"
                 },
                 "bcc": {
                   "type": [

--- a/resend.json
+++ b/resend.json
@@ -3150,6 +3150,11 @@
             "description": "The ID of the email.",
             "example": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
           },
+          "message_id": {
+            "type": "string",
+            "description": "The Message-ID header value of the email.",
+            "example": "<202301010000.4ef9a417@resend.dev>"
+          },
           "to": {
             "type": "array",
             "items": {

--- a/resend.yaml
+++ b/resend.yaml
@@ -2303,7 +2303,7 @@ components:
         message_id:
           type: string
           description: The Message-ID header value of the email.
-          example: '<202301010000.4ef9a417@resend.dev>'
+          example: '<202301010000.4ef9a417@email.example.com>'
         to:
           type: array
           items:
@@ -3646,7 +3646,7 @@ components:
         message_id:
           type: string
           description: The unique message ID from the email headers.
-          example: '<message-id@example.com>'
+          example: '<message-id@email.example.com>'
         bcc:
           type: [array, "null"]
           items:
@@ -3751,7 +3751,7 @@ components:
               message_id:
                 type: string
                 description: The unique message ID from the email headers.
-                example: '<message-id@example.com>'
+                example: '<message-id@email.example.com>'
               bcc:
                 type: [array, "null"]
                 items:

--- a/resend.yaml
+++ b/resend.yaml
@@ -2300,6 +2300,10 @@ components:
           type: string
           description: The ID of the email.
           example: '4ef9a417-02e9-4d39-ad75-9611e0fcc33c'
+        message_id:
+          type: string
+          description: The Message-ID header value of the email.
+          example: '<202301010000.4ef9a417@resend.dev>'
         to:
           type: array
           items:


### PR DESCRIPTION
## Summary
- Add a `message_id: string` property to the shared `Email` schema, exposing the new key returned by the API.
- This covers both `GET /emails/{email_id}` (returns `Email`) and `GET /emails` (returns `ListEmailsResponse`, whose `data` items reference `Email`).
- Mirrored the change in both `resend.yaml` and `resend.json`.

## Test plan
- [ ] Validate the OpenAPI spec parses correctly (yaml/json in sync).
- [ ] Confirm `message_id` appears in the generated docs/SDK for the email retrieve and list endpoints.

Made with [Cursor](https://cursor.com)