### PR TITLE
docs: add received_for to inbound email responses

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -3665,6 +3665,12 @@ components:
             type: string
           description: The reply-to addresses.
           example: []
+        received_for:
+          type: array
+          items:
+            type: string
+          description: The recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers. Empty when the email was delivered directly without forwarding.
+          example: ['forwarded@example.com']
         html:
           type: [string, "null"]
           description: The HTML content of the email.
@@ -5633,6 +5639,11 @@ components:
           items:
             type: string
           description: CC recipients.
+        received_for:
+          type: array
+          items:
+            type: string
+          description: The recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers. Empty when the email was delivered directly without forwarding.
         attachments:
           type: array
           items:

--- a/resend.yaml
+++ b/resend.yaml
@@ -3669,7 +3669,7 @@ components:
           type: array
           items:
             type: string
-          description: The recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers. Empty when the email was delivered directly without forwarding.
+          description: The recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers.
           example: ['forwarded@example.com']
         html:
           type: [string, "null"]
@@ -5643,7 +5643,7 @@ components:
           type: array
           items:
             type: string
-          description: The recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers. Empty when the email was delivered directly without forwarding.
+          description: The recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers.
         attachments:
           type: array
           items:


### PR DESCRIPTION
## Context

[Slack thread](https://resend.slack.com/archives/C0AJSRCBLT1/p1782424744720579)

**Opened on behalf of:** @lucasfcosta

## What

Documents the new `received_for` field (merged in resend-monorepo #4637) in the OpenAPI spec.

- `GetReceivedEmailResponse` — adds `received_for` (array of strings) to the retrieve-received-email response.
- `EmailReceivedEventData` — adds `received_for` to the `email.received` webhook payload.

## Why

The field is already returned by the GET `/emails/receiving/:id` route and the `email.received` webhook, but wasn't described in the spec.

## How

Edited `resend.yaml` only (`resend.json` is auto-generated on push to main).
