### PR TITLE
feat: add OAuth grants endpoints (list + revoke)

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -606,6 +606,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListOAuthGrantsResponse'
+  /oauth/grants/{oauth_grant_id}:
+    delete:
+      tags:
+        - OAuth
+      summary: Revoke an OAuth grant
+      parameters:
+        - name: oauth_grant_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The OAuth grant ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevokeOAuthGrantResponse'
   /templates:
     post:
       tags:
@@ -2926,6 +2945,23 @@ components:
             logo_uri:
               type: [string, "null"]
               description: The URL of the OAuth client's logo.
+    RevokeOAuthGrantResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: The type of object.
+          example: 'oauth_grant'
+        id:
+          type: string
+          description: The ID of the OAuth grant.
+        revoked_at:
+          type: string
+          format: date-time
+          description: The date and time the OAuth grant was revoked.
+        revoked_reason:
+          type: string
+          description: The reason the OAuth grant was revoked.
     DeleteApiKeyResponse:
       type: object
       properties:

--- a/resend.yaml
+++ b/resend.yaml
@@ -2909,6 +2909,13 @@ components:
           type: string
           format: date-time
           description: The date and time the OAuth grant was created.
+        revoked_at:
+          type: [string, "null"]
+          format: date-time
+          description: The date and time the OAuth grant was revoked, or null if it is still active.
+        revoked_reason:
+          type: [string, "null"]
+          description: The reason the OAuth grant was revoked, or null if it is still active.
         client:
           type: object
           description: The OAuth client the grant was issued to.

--- a/resend.yaml
+++ b/resend.yaml
@@ -40,6 +40,8 @@ tags:
     description: Create and manage Automations through the Resend API.
   - name: Events
     description: Create and manage Events through the Resend API.
+  - name: OAuth
+    description: List and manage OAuth grants through the Resend API.
 paths:
   /emails:
     post:
@@ -588,6 +590,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteApiKeyResponse'
+  /oauth/grants:
+    get:
+      tags:
+        - OAuth
+      summary: Retrieve a list of OAuth grants
+      parameters:
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationAfter'
+        - $ref: '#/components/parameters/PaginationBefore'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListOAuthGrantsResponse'
   /templates:
     post:
       tags:
@@ -2855,6 +2873,52 @@ components:
           type: [string, "null"]
           format: date-time
           description: The date and time the API key was last used.
+    ListOAuthGrantsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: 'list'
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+          example: false
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/OAuthGrant'
+    OAuthGrant:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the OAuth grant.
+        client_id:
+          type: string
+          description: The ID of the OAuth client the grant was issued to.
+        scopes:
+          type: array
+          items:
+            type: string
+          description: The scopes granted to the OAuth client.
+        resource:
+          type: [string, "null"]
+          description: The resource the grant is scoped to, if any.
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time the OAuth grant was created.
+        client:
+          type: object
+          description: The OAuth client the grant was issued to.
+          properties:
+            name:
+              type: string
+              description: The name of the OAuth client.
+            logo_uri:
+              type: [string, "null"]
+              description: The URL of the OAuth client's logo.
     DeleteApiKeyResponse:
       type: object
       properties:


### PR DESCRIPTION
## What

Documents the OAuth grants endpoints so SDKs can implement them:

- **`GET /oauth/grants`** — list a team's OAuth grants (Public API: resend/resend-monorepo#5275)
- **`DELETE /oauth/grants/{oauth_grant_id}`** — revoke an OAuth grant (Public API: resend/resend-monorepo#5260, already merged)

## Changes (`resend.yaml` only)

- New `OAuth` tag.
- `GET /oauth/grants` — mirrors `/api-keys` (shared pagination `$ref`s, global `bearerAuth`), returns `ListOAuthGrantsResponse`.
- `DELETE /oauth/grants/{oauth_grant_id}` — path param `oauth_grant_id`, returns `RevokeOAuthGrantResponse`.
- Schemas:
  - `ListOAuthGrantsResponse` + `OAuthGrant` (`id`, `client_id`, `scopes`, `resource`, `created_at`, `revoked_at`, `revoked_reason`, nested `client { name, logo_uri }`). The list returns all grants (active and revoked); `revoked_at` / `revoked_reason` are `null` for active grants.
  - `RevokeOAuthGrantResponse` (`object`, `id`, `revoked_at`, `revoked_reason`).

`resend.json` is intentionally **not** edited — it is auto-generated from `resend.yaml` by CI on merge to `main` (`.github/workflows/generate-json.yml`).

## Validation

YAML parses and all new keys resolve (`yq -e` on the tag, both paths, and all schemas).
