### PR TITLE
feat: remove unused resource field from OAuthGrant schema

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -2921,9 +2921,6 @@ components:
           items:
             type: string
           description: The scopes granted to the OAuth client.
-        resource:
-          type: [string, "null"]
-          description: The resource the grant is scoped to, if any.
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
Removes the unused `resource` field from the `OAuthGrant` schema, matching the API change in resend-monorepo#5372 which drops `resource` from the `/oauth/grants` response.

Part of the chain to remove the field everywhere: OpenAPI spec → resend-node SDK → resend-cli → remono MCP → OSS MCP.