### PR TITLE
feat: add bounce details to Email response schema

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -2542,6 +2542,24 @@ components:
             - sent
             - suppressed
           example: 'delivered'
+        bounce:
+          type: object
+          description: Details about the bounce, present only when `last_event` is `bounced`.
+          properties:
+            message:
+              type: [string, "null"]
+              description: A human-readable message describing the bounce.
+            type:
+              type: [string, "null"]
+              description: The type of bounce, as reported by the receiving mail server (e.g. `Permanent`, `Transient`).
+            subType:
+              type: [string, "null"]
+              description: The subtype of the bounce, as reported by the receiving mail server (e.g. `General`, `NoEmail`).
+            diagnosticCode:
+              type: array
+              items:
+                type: string
+              description: Diagnostic codes returned by the receiving mail server for each bounced recipient.
     ListEmailsResponse:
       type: object
       properties:

--- a/resend.yaml
+++ b/resend.yaml
@@ -2551,10 +2551,26 @@ components:
               description: A human-readable message describing the bounce.
             type:
               type: [string, "null"]
-              description: The type of bounce, as reported by the receiving mail server (e.g. `Permanent`, `Transient`).
+              enum:
+                - Undetermined
+                - Transient
+                - Permanent
+                - null
+              description: The type of bounce, as reported by AWS SES.
+              example: 'Permanent'
             subType:
               type: [string, "null"]
-              description: The subtype of the bounce, as reported by the receiving mail server (e.g. `General`, `NoEmail`).
+              enum:
+                - Undetermined
+                - General
+                - NoEmail
+                - MailboxFull
+                - MessageTooLarge
+                - ContentRejected
+                - AttachmentRejected
+                - null
+              description: The subtype of the bounce, as reported by AWS SES.
+              example: 'General'
             diagnosticCode:
               type: array
               items:


### PR DESCRIPTION
## Summary
- Adds a `bounce` field to the shared `Email` schema in `resend.yaml` (message, type, subType, diagnosticCode), matching the new response shape returned by `GET /emails/:id` in the public-api (resend-monorepo PR: bounce details on email get).
- `resend.json` is intentionally left untouched — it's auto-generated by CI from `resend.yaml` on push to `main`.

## Test plan
- [x] Validated `resend.yaml` parses correctly
- [x] Confirmed the `Email` schema is shared across `GET /emails/{email_id}`, `POST /emails/{email_id}/cancel`, and `ListEmailsResponse`, so no other schema needed updating