### PR TITLE
chore: revert bounce object from Email response schema

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -2517,40 +2517,6 @@ components:
             - sent
             - suppressed
           example: 'delivered'
-        bounce:
-          type: object
-          description: Details about the bounce, present only when `last_event` is `bounced`.
-          properties:
-            message:
-              type: [string, "null"]
-              description: A human-readable message describing the bounce.
-            type:
-              type: [string, "null"]
-              enum:
-                - Undetermined
-                - Transient
-                - Permanent
-                - null
-              description: The type of bounce, as reported by AWS SES.
-              example: 'Permanent'
-            subType:
-              type: [string, "null"]
-              enum:
-                - Undetermined
-                - General
-                - NoEmail
-                - MailboxFull
-                - MessageTooLarge
-                - ContentRejected
-                - AttachmentRejected
-                - null
-              description: The subtype of the bounce, as reported by AWS SES.
-              example: 'General'
-            diagnosticCode:
-              type: array
-              items:
-                type: string
-              description: Diagnostic codes returned by the receiving mail server for each bounced recipient.
     ListEmailsResponse:
       type: object
       properties:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reverts #80, which added the `bounce` object to the Email response schema in `resend.yaml`.

This removes the optional `bounce` property (`message`, `type`, `subType`, `diagnosticCode`) from the Email schema.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81ae3b82-42da-42a4-83e1-5e22733d38a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81ae3b82-42da-42a4-83e1-5e22733d38a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

