### PR TITLE
fix: stop declaring format: date-time on Postgres timestamps

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -2,13 +2,7 @@ openapi: 3.1.2
 info:
   title: Resend
   version: 1.5.0
-  description: |
-    Resend is the email platform for developers.
-
-    Most timestamps are Postgres format (`2023-10-06 23:47:56.678+00`), not ISO
-    8601. Fractional seconds are variable width and absent on a whole second, so
-    do not assume a fixed number of digits. Fields that return ISO 8601 are
-    typed `format: date-time`.
+  description: 'Resend is the email platform for developers.'
 servers:
   - url: https://api.resend.com
 security:

--- a/resend.yaml
+++ b/resend.yaml
@@ -2,7 +2,26 @@ openapi: 3.1.2
 info:
   title: Resend
   version: 1.5.0
-  description: 'Resend is the email platform for developers.'
+  description: |
+    Resend is the email platform for developers.
+
+    ## Timestamps
+
+    Timestamps in API responses use Postgres timestamp format, in UTC:
+
+    `YYYY-MM-DD HH:MM:SS[.ffffff]+00` — for example, `2023-10-06 23:47:56.678+00`.
+
+    This is not ISO 8601. It uses a space instead of a `T` separator and a
+    two-digit offset, so strict ISO 8601 and RFC 3339 parsers reject it. These
+    fields are therefore typed as plain strings rather than `format: date-time`.
+
+    Fractional seconds are variable width: one to six digits, and omitted
+    entirely when the value falls on a whole second. Do not use a parser that
+    expects a fixed number of digits.
+
+    Webhook event payloads, the received email endpoints, attachment
+    `expires_at`, and `revoked_at` on `DELETE /oauth/grants/{oauth_grant_id}`
+    are the exceptions — they return ISO 8601 and keep `format: date-time`.
 servers:
   - url: https://api.resend.com
 security:
@@ -2471,9 +2490,8 @@ components:
           example: 'Acme <onboarding@resend.dev>'
         created_at:
           type: string
-          format: date-time
           description: The date and time the email was created.
-          example: '2023-04-03T22:13:42.674981+00:00'
+          example: '2023-04-03 22:13:42.674981+00'
         subject:
           type: string
           description: The subject line of the email.
@@ -2609,8 +2627,8 @@ components:
           description: The name of the domain.
         created_at:
           type: string
-          format: date-time
           description: The date and time the domain was created.
+          example: '2023-10-06 23:47:56.678+00'
         status:
           type: string
           enum:
@@ -2726,9 +2744,8 @@ components:
           example: 'not_started'
         created_at:
           type: string
-          format: date-time
           description: The date and time the domain was created.
-          example: '2023-04-26T20:21:26.347412+00:00'
+          example: '2023-04-26 20:21:26.347412+00'
         region:
           type: string
           description: The region where the domain is hosted.
@@ -2859,14 +2876,12 @@ components:
           example: null
         created_at:
           type: string
-          format: date-time
           description: The date and time the claim was created.
-          example: '2023-04-26T20:21:26.347412+00:00'
+          example: '2023-04-26 20:21:26.347412+00'
         expires_at:
           type: string
-          format: date-time
           description: The date and time the claim expires if not verified.
-          example: '2023-05-03T20:21:26.347412+00:00'
+          example: '2023-05-03 20:21:26.347412+00'
     VerifyDomainResponse:
       type: object
       properties:
@@ -2917,9 +2932,8 @@ components:
           example: 'not_started'
         created_at:
           type: string
-          format: date-time
           description: The date and time the domain was created.
-          example: '2023-04-26T20:21:26.347412+00:00'
+          example: '2023-04-26 20:21:26.347412+00'
         region:
           type: string
           description: The region where the domain is hosted.
@@ -3004,12 +3018,12 @@ components:
           description: The name of the API key.
         created_at:
           type: string
-          format: date-time
           description: The date and time the API key was created.
+          example: '2023-10-06 23:47:56.678+00'
         last_used_at:
           type: [string, "null"]
-          format: date-time
           description: The date and time the API key was last used.
+          example: '2023-10-06 23:47:56.678+00'
     ListOAuthGrantsResponse:
       type: object
       properties:
@@ -3041,12 +3055,12 @@ components:
           description: The scopes granted to the OAuth client.
         created_at:
           type: string
-          format: date-time
           description: The date and time the OAuth grant was created.
+          example: '2023-10-06 23:47:56.678+00'
         revoked_at:
           type: [string, "null"]
-          format: date-time
           description: The date and time the OAuth grant was revoked, or null if it is still active.
+          example: '2023-10-06 23:47:56.678+00'
         revoked_reason:
           type: [string, "null"]
           description: The reason the OAuth grant was revoked, or null if it is still active.
@@ -3074,6 +3088,7 @@ components:
           type: string
           format: date-time
           description: The date and time the OAuth grant was revoked.
+          example: '2023-10-06T23:47:56.678Z'
         revoked_reason:
           type: string
           description: The reason the OAuth grant was revoked.
@@ -3135,7 +3150,7 @@ components:
         created_at:
           type: string
           description: The date that the object was created.
-          example: 2023-10-06T22:59:55.977Z
+          example: '2023-10-06 22:59:55.977+00'
     RemoveAudienceResponseSuccess:
       type: object
       deprecated: true
@@ -3176,9 +3191,8 @@ components:
                 example: Registered Users
               created_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the audience was created.
-                example: "2023-10-06T22:59:55.977Z"
+                example: "2023-10-06 22:59:55.977+00"
     CreateContactOptions:
       type: object
       required:
@@ -3265,9 +3279,8 @@ components:
           example: Wozniak
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the contact was created.
-          example: "2023-10-06T23:47:56.678Z"
+          example: "2023-10-06 23:47:56.678+00"
         unsubscribed:
           type: boolean
           description: Indicates if the contact is unsubscribed.
@@ -3356,9 +3369,8 @@ components:
                 example: Wozniak
               created_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the contact was created.
-                example: "2023-10-06T23:47:56.678Z"
+                example: "2023-10-06 23:47:56.678+00"
               unsubscribed:
                 type: boolean
                 description: Indicates if the contact is unsubscribed.
@@ -3450,14 +3462,12 @@ components:
           example: completed
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the contact import was created.
-          example: "2023-10-06T23:47:56.678Z"
+          example: "2023-10-06 23:47:56.678+00"
         completed_at:
           type: [string, "null"]
-          format: date-time
           description: Timestamp indicating when the contact import completed.
-          example: "2023-10-06T23:50:56.678Z"
+          example: "2023-10-06 23:50:56.678+00"
         counts:
           $ref: '#/components/schemas/ContactImportCounts'
     GetContactImportResponseSuccess:
@@ -3579,19 +3589,16 @@ components:
                 example: 'draft'
               created_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the broadcast was created.
-                example: "2023-10-06T22:59:55.977Z"
+                example: "2023-10-06 22:59:55.977+00"
               scheduled_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the broadcast is scheduled to be sent.
-                example: "2023-10-06T22:59:55.977Z"
+                example: "2023-10-06 22:59:55.977+00"
               sent_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the broadcast was sent.
-                example: "2023-10-06T22:59:55.977Z"
+                example: "2023-10-06 22:59:55.977+00"
               topic_id:
                 type: string
                 description: The topic ID that the broadcast is scoped to.
@@ -3637,19 +3644,16 @@ components:
           example: 'draft'
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the broadcast was created.
-          example: "2023-10-06T22:59:55.977Z"
+          example: "2023-10-06 22:59:55.977+00"
         scheduled_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the broadcast is scheduled to be sent.
-          example: "2023-10-06T22:59:55.977Z"
+          example: "2023-10-06 22:59:55.977+00"
         sent_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the broadcast was sent.
-          example: "2023-10-06T22:59:55.977Z"
+          example: "2023-10-06 22:59:55.977+00"
         text:
           type: [string, "null"]
           description: The plain text version of the broadcast content.
@@ -3903,7 +3907,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the email was received.
-          example: '2023-10-06:23:47:56.678Z'
+          example: '2023-10-06T23:47:56.678Z'
         attachments:
           type: array
           description: Array of attachments.
@@ -4085,9 +4089,8 @@ components:
           example: 'enabled'
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the webhook was created.
-          example: '2023-10-06T23:47:56.678Z'
+          example: '2023-10-06 23:47:56.678+00'
         signing_secret:
           type: string
           description: The secret key used to verify webhook payloads.
@@ -4130,9 +4133,8 @@ components:
                 example: 'enabled'
               created_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the webhook was created.
-                example: '2023-10-06T23:47:56.678Z'
+                example: '2023-10-06 23:47:56.678+00'
     UpdateWebhookRequest:
       type: object
       properties:
@@ -4206,12 +4208,12 @@ components:
               items: {}
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the variable was created.
+          example: '2023-10-06 23:47:56.678+00'
         updated_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the variable was last updated.
+          example: '2023-10-06 23:47:56.678+00'
       required:
         - key
         - type
@@ -4279,20 +4281,20 @@ components:
             $ref: '#/components/schemas/TemplateVariable'
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the template was created.
+          example: '2023-10-06 23:47:56.678+00'
         updated_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the template was last updated.
+          example: '2023-10-06 23:47:56.678+00'
         status:
           type: string
           description: The publication status of the template.
           enum: [draft, published]
         published_at:
           type: [string, "null"]
-          format: date-time
           description: Timestamp indicating when the template was published.
+          example: '2023-10-06 23:47:56.678+00'
         has_unpublished_versions:
           type: boolean
           description: Indicates whether the template has unpublished versions.
@@ -4311,16 +4313,16 @@ components:
           enum: [draft, published]
         published_at:
           type: [string, "null"]
-          format: date-time
           description: Timestamp indicating when the template was published.
+          example: '2023-10-06 23:47:56.678+00'
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the template was created.
+          example: '2023-10-06 23:47:56.678+00'
         updated_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the template was last updated.
+          example: '2023-10-06 23:47:56.678+00'
         alias:
           type: string
           description: The alias of the template.
@@ -4506,8 +4508,8 @@ components:
           description: Filter conditions for the segment.
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the segment was created.
+          example: '2023-10-06 23:47:56.678+00'
     ListSegmentsResponseSuccess:
       type: object
       properties:
@@ -4536,8 +4538,8 @@ components:
                 deprecated: true
               created_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the segment was created.
+                example: '2023-10-06 23:47:56.678+00'
     RemoveSegmentResponseSuccess:
       type: object
       properties:
@@ -4623,8 +4625,8 @@ components:
           description: The visibility of the topic.
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the topic was created.
+          example: '2023-10-06 23:47:56.678+00'
     ListTopicsResponseSuccess:
       type: object
       properties:
@@ -4664,8 +4666,8 @@ components:
                 description: The visibility of the topic.
               created_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the topic was created.
+                example: '2023-10-06 23:47:56.678+00'
     UpdateTopicOptions:
       type: object
       properties:
@@ -4767,8 +4769,8 @@ components:
           example: Acme Corp
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the contact property was created.
+          example: '2023-10-06 23:47:56.678+00'
     ListContactPropertiesResponseSuccess:
       type: object
       properties:
@@ -4801,8 +4803,8 @@ components:
                 description: The default value when the property is not set for a contact.
               created_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the contact property was created.
+                example: '2023-10-06 23:47:56.678+00'
     UpdateContactPropertyOptions:
       type: object
       properties:
@@ -4874,8 +4876,8 @@ components:
                 description: Name of the segment.
               created_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the contact was added to the segment.
+                example: '2023-10-06 23:47:56.678+00'
     RemoveContactFromSegmentResponseSuccess:
       type: object
       properties:
@@ -4977,8 +4979,8 @@ components:
           description: The log ID.
         created_at:
           type: string
-          format: date-time
           description: The date the log was created.
+          example: '2023-10-06 23:47:56.678+00'
         endpoint:
           type: string
           description: The API endpoint that was called.
@@ -5011,8 +5013,8 @@ components:
           description: The log ID.
         created_at:
           type: string
-          format: date-time
           description: The date the log was created.
+          example: '2023-10-06 23:47:56.678+00'
         endpoint:
           type: string
           description: The API endpoint that was called.
@@ -5199,9 +5201,11 @@ components:
         created_at:
           type: string
           description: The date and time the automation was created.
+          example: '2023-10-06 23:47:56.678+00'
         updated_at:
           type: string
           description: The date and time the automation was last updated.
+          example: '2023-10-06 23:47:56.678+00'
         steps:
           type: array
           description: The steps in the active version of the automation.
@@ -5230,9 +5234,11 @@ components:
         created_at:
           type: string
           description: The date and time the automation was created.
+          example: '2023-10-06 23:47:56.678+00'
         updated_at:
           type: string
           description: The date and time the automation was last updated.
+          example: '2023-10-06 23:47:56.678+00'
     ListAutomationsResponse:
       type: object
       properties:
@@ -5339,9 +5345,11 @@ components:
         started_at:
           type: [string, "null"]
           description: The date and time the step started executing.
+          example: '2023-10-06 23:47:56.678+00'
         completed_at:
           type: [string, "null"]
           description: The date and time the step completed executing.
+          example: '2023-10-06 23:47:56.678+00'
         output:
           type: [object, "null"]
           description: The output produced by the step, if any.
@@ -5351,6 +5359,7 @@ components:
         created_at:
           type: string
           description: The date and time the step record was created.
+          example: '2023-10-06 23:47:56.678+00'
     AutomationRun:
       type: object
       properties:
@@ -5372,12 +5381,15 @@ components:
         started_at:
           type: [string, "null"]
           description: The date and time the run started.
+          example: '2023-10-06 23:47:56.678+00'
         completed_at:
           type: [string, "null"]
           description: The date and time the run completed.
+          example: '2023-10-06 23:47:56.678+00'
         created_at:
           type: string
           description: The date and time the run was created.
+          example: '2023-10-06 23:47:56.678+00'
         steps:
           type: array
           description: The steps executed in this run, sorted in graph order.
@@ -5400,12 +5412,15 @@ components:
         started_at:
           type: [string, "null"]
           description: The date and time the run started.
+          example: '2023-10-06 23:47:56.678+00'
         completed_at:
           type: [string, "null"]
           description: The date and time the run completed.
+          example: '2023-10-06 23:47:56.678+00'
         created_at:
           type: string
           description: The date and time the run was created.
+          example: '2023-10-06 23:47:56.678+00'
     ListAutomationRunsResponse:
       type: object
       properties:
@@ -5441,9 +5456,11 @@ components:
         created_at:
           type: string
           description: The date and time the event was created.
+          example: '2023-10-06 23:47:56.678+00'
         updated_at:
           type: [string, "null"]
           description: The date and time the event was last updated.
+          example: '2023-10-06 23:47:56.678+00'
     EventSummary:
       type: object
       properties:
@@ -5460,9 +5477,11 @@ components:
         created_at:
           type: string
           description: The date and time the event was created.
+          example: '2023-10-06 23:47:56.678+00'
         updated_at:
           type: [string, "null"]
           description: The date and time the event was last updated.
+          example: '2023-10-06 23:47:56.678+00'
     CreateEventRequest:
       type: object
       required:
@@ -5617,6 +5636,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the click occurred.
+          example: '2023-10-06T23:47:56.678Z'
         userAgent:
           type: string
           description: User agent string of the browser that clicked the link.
@@ -5740,6 +5760,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the email was created.
+          example: '2023-10-06T23:47:56.678Z'
         from:
           type: string
           description: Sender email address and name in the format `Name <email@domain.com>`.
@@ -5831,6 +5852,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the email was received.
+          example: '2023-10-06T23:47:56.678Z'
         from:
           type: string
           description: Sender email address.
@@ -5884,10 +5906,12 @@ components:
           type: string
           format: date-time
           description: Timestamp when the contact was created.
+          example: '2023-10-06T23:47:56.678Z'
         updated_at:
           type: string
           format: date-time
           description: Timestamp when the contact was last updated.
+          example: '2023-10-06T23:47:56.678Z'
         email:
           type: string
           description: Contact's email address.
@@ -5930,6 +5954,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the domain was created.
+          example: '2023-10-06T23:47:56.678Z'
         region:
           type: string
           enum:
@@ -5958,6 +5983,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/OutboundEmailEventData'
     EmailDeliveredEvent:
@@ -5975,6 +6001,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/OutboundEmailEventData'
     EmailDeliveryDelayedEvent:
@@ -5992,6 +6019,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/OutboundEmailEventData'
     EmailBouncedEvent:
@@ -6009,6 +6037,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/EmailBouncedEventData'
     EmailComplainedEvent:
@@ -6026,6 +6055,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/OutboundEmailEventData'
     EmailOpenedEvent:
@@ -6043,6 +6073,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/OutboundEmailEventData'
     EmailClickedEvent:
@@ -6060,6 +6091,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/EmailClickedEventData'
     EmailFailedEvent:
@@ -6077,6 +6109,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/EmailFailedEventData'
     EmailScheduledEvent:
@@ -6094,6 +6127,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/OutboundEmailEventData'
     EmailSuppressedEvent:
@@ -6111,6 +6145,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/EmailSuppressedEventData'
     EmailReceivedEvent:
@@ -6128,6 +6163,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/EmailReceivedEventData'
     ContactCreatedEvent:
@@ -6145,6 +6181,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/ContactEventData'
     ContactUpdatedEvent:
@@ -6162,6 +6199,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/ContactEventData'
     ContactDeletedEvent:
@@ -6179,6 +6217,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/ContactEventData'
     DomainCreatedEvent:
@@ -6196,6 +6235,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/DomainEventData'
     DomainUpdatedEvent:
@@ -6213,6 +6253,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/DomainEventData'
     DomainDeletedEvent:
@@ -6230,6 +6271,7 @@ components:
           type: string
           format: date-time
           description: Timestamp when the event was emitted.
+          example: '2023-10-06T23:47:56.678Z'
         data:
           $ref: '#/components/schemas/DomainEventData'
     CreateSuppressionOptions:
@@ -6371,9 +6413,8 @@ components:
           example: 479e3145-dd38-476b-932c-529ceb705947
         created_at:
           type: string
-          format: date-time
           description: Timestamp indicating when the suppression was created.
-          example: "2023-10-06T23:47:56.678Z"
+          example: "2023-10-06 23:47:56.678+00"
     ListSuppressionsResponseSuccess:
       type: object
       properties:
@@ -6413,6 +6454,5 @@ components:
                 example: 479e3145-dd38-476b-932c-529ceb705947
               created_at:
                 type: string
-                format: date-time
                 description: Timestamp indicating when the suppression was created.
-                example: "2023-10-06T23:47:56.678Z"
+                example: "2023-10-06 23:47:56.678+00"

--- a/resend.yaml
+++ b/resend.yaml
@@ -5,23 +5,10 @@ info:
   description: |
     Resend is the email platform for developers.
 
-    ## Timestamps
-
-    Timestamps in API responses use Postgres timestamp format, in UTC:
-
-    `YYYY-MM-DD HH:MM:SS[.ffffff]+00` — for example, `2023-10-06 23:47:56.678+00`.
-
-    This is not ISO 8601. It uses a space instead of a `T` separator and a
-    two-digit offset, so strict ISO 8601 and RFC 3339 parsers reject it. These
-    fields are therefore typed as plain strings rather than `format: date-time`.
-
-    Fractional seconds are variable width: one to six digits, and omitted
-    entirely when the value falls on a whole second. Do not use a parser that
-    expects a fixed number of digits.
-
-    Webhook event payloads, the received email endpoints, attachment
-    `expires_at`, and `revoked_at` on `DELETE /oauth/grants/{oauth_grant_id}`
-    are the exceptions — they return ISO 8601 and keep `format: date-time`.
+    Most timestamps are Postgres format (`2023-10-06 23:47:56.678+00`), not ISO
+    8601. Fractional seconds are variable width and absent on a whole second, so
+    do not assume a fixed number of digits. Fields that return ISO 8601 are
+    typed `format: date-time`.
 servers:
   - url: https://api.resend.com
 security:


### PR DESCRIPTION
Our API returns timestamps in Postgres format 0 `2023-10-06 23:47:56.678+00` - not ISO 8601. All 233 timestamp columns across our database packages are declared `mode: 'string'` in Drizzle, so any route that returns a column ships that format to the client.

This spec declared `format: date-time` on 70 fields and carried only ISO examples. In OpenAPI, `format: date-time` is defined as RFC 3339.

## What changed

**42 fields: dropped `format: date-time`, added a Postgres-format example.** These all return a raw column: `Email`, `Domain`, `ListDomainsItem`, `CreateDomainResponse`, `DomainClaim`, `ApiKey`, `OAuthGrant`, audiences, contacts, `ContactImport`, broadcasts, templates and `TemplateVariable`, segments, topics, contact properties, `Log`/`LogSummary`, webhooks, and suppressions. Type stays `string`, so a generator now produces a plain string instead of a date type.

**28 fields: kept `format: date-time`, normalized the examples.**

| Surface | Why |
| --- | --- |
| All webhook event envelopes and data objects | Deliveries pass through `parsePostgresDateToISOFormat()` |
| `GetReceivedEmailResponse`, `ListReceivedEmailsResponse` | The received-email routes convert explicitly |
| `RetrievedAttachment.expires_at`, `ListAttachmentsResponse` | Computed in JavaScript |
| `RevokeOAuthGrantResponse.revoked_at` | Assigned from an ISO string in the route |

Note `OAuthGrant.revoked_at` (used by `GET /oauth/grants`) is Postgres while `RevokeOAuthGrantResponse.revoked_at` (`DELETE /oauth/grants/{oauth_grant_id}`) is ISO.

**18 fields: added a Postgres example.** Automation, automation run, automation run step, and event timestamps had no `format` and no `example`, so the format was left to inference — which is how the docs drifted to claiming ISO in the first place. Request-side `scheduled_at` fields are deliberately untouched; they accept ISO 8601 or natural language.

**Two example bugs fixed.** `GetReceivedEmailResponse.created_at` was `2023-10-06:23:47:56.678Z`, with a colon where the `T` belongs. `GetAudienceResponseSuccess.created_at` was unquoted, so YAML parsed it as a timestamp rather than a string.

⚠️ Fractional seconds are variable width — Postgres strips trailing zeros, so `.678+00`, `.84216+00` and a bare `+00` all occur.
