### PR TITLE
feat: add broadcasts/{id}/cancel endpoint

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -1115,7 +1115,6 @@ paths:
       summary: Cancel a broadcast
       description: >-
         Cancels a broadcast that is queued or scheduled. Canceling a
-        scheduled broadcast also cancels the scheduled delivery. Canceling a
         queued broadcast stops it mid-send; emails already sent are not
         affected, but no further emails will go out.
       parameters:

--- a/resend.yaml
+++ b/resend.yaml
@@ -1108,6 +1108,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SendBroadcastResponseSuccess'
+  /broadcasts/{id}/cancel:
+    post:
+      tags:
+        - Broadcasts
+      summary: Cancel a broadcast
+      description: >-
+        Cancels a broadcast that is queued or scheduled. Canceling a
+        scheduled broadcast also cancels the scheduled delivery. Canceling a
+        queued broadcast stops it mid-send; emails already sent are not
+        affected, but no further emails will go out.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The Broadcast ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CancelBroadcastResponseSuccess'
   /webhooks:
     post:
       tags:
@@ -3722,6 +3747,17 @@ components:
           type: string
           description: The ID of the broadcast.
           example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+    CancelBroadcastResponseSuccess:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the broadcast.
+          example: 78261eea-8f8b-4381-83c6-79fa7120f1cf
+        object:
+          type: string
+          description: The object type of the response.
+          example: broadcast
     RetrievedAttachment:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- Adds `POST /broadcasts/{id}/cancel` and `CancelBroadcastResponseSuccess` to the spec, mirroring the shape of `send`/`update`/`remove` broadcast responses.

Companion PRs: resend/resend-node#1059, resend/resend-docs#1722, resend/resend-monorepo#8126.

## Test plan
- [x] `yq -o=json resend.yaml` — valid YAML, resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)