### PR TITLE
fix: add open_tracking/click_tracking to ListDomainsItem schema

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -2943,6 +2943,12 @@ components:
           type: string
           description: The region where the domain is hosted.
           example: 'us-east-1'
+        open_tracking:
+          type: boolean
+          description: Whether open tracking is enabled for this domain.
+        click_tracking:
+          type: boolean
+          description: Whether click tracking is enabled for this domain.
         capabilities:
           $ref: '#/components/schemas/DomainCapabilities'
     UpdateDomainResponseSuccess:


### PR DESCRIPTION
## Summary
- `ListDomainsItem` was missing `open_tracking`/`click_tracking`, even though `GET /domains/:id` (and now `GET /domains` too, after resend/resend-monorepo#8233) return both fields per domain.
- Added both as `boolean` to `ListDomainsItem`, matching the descriptions already used on `CreateDomainResponse`/`UpdateDomainOptions`.