### PR TITLE
feat: add automations/{automation_id}/duplicate endpoint

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -1836,6 +1836,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteAutomationResponse'
+  /automations/{automation_id}/duplicate:
+    post:
+      operationId: automations/duplicate
+      tags:
+        - Automations
+      summary: Duplicate an automation
+      parameters:
+        - name: automation_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The ID of the automation.
+      responses:
+        '201':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DuplicateAutomationResponse'
   /automations/{automation_id}/stop:
     post:
       operationId: automations/stop
@@ -5426,6 +5447,23 @@ components:
           type: boolean
           description: Indicates whether the automation was successfully deleted.
           example: true
+    DuplicateAutomationResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: automation
+        id:
+          type: string
+          description: The ID of the duplicated automation.
+        version_id:
+          type: string
+          description: The ID of the duplicated automation version.
+        version_status:
+          type: string
+          description: The status of the duplicated automation version.
+          example: draft
     StopAutomationResponse:
       type: object
       properties:

--- a/resend.yaml
+++ b/resend.yaml
@@ -5457,13 +5457,6 @@ components:
         id:
           type: string
           description: The ID of the duplicated automation.
-        version_id:
-          type: string
-          description: The ID of the duplicated automation version.
-        version_status:
-          type: string
-          description: The status of the duplicated automation version.
-          example: draft
     StopAutomationResponse:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- Adds `POST /automations/{automation_id}/duplicate` and `DuplicateAutomationResponse` (`object`, `id`, `version_id`, `version_status`) to match the public API (resend/resend-monorepo#8306).

`resend.json` is not edited — CI generates it from `resend.yaml` on merge to `main`.

## Test plan
- [x] `yq` — YAML parses; path and schema keys resolve


Made with [Cursor](https://cursor.com)