### PR TITLE
fix: add received_for to the received email and email.received schemas

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -4032,6 +4032,12 @@ components:
             type: string
           description: The reply-to addresses.
           example: []
+        received_for:
+          type: array
+          items:
+            type: string
+          description: The recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers.
+          example: ['forwarded@example.com']
         html:
           type: [string, "null"]
           description: The HTML content of the email.
@@ -6028,6 +6034,12 @@ components:
           items:
             type: string
           description: CC recipients.
+        received_for:
+          type: array
+          items:
+            type: string
+          description: The recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers.
+          example: ['forwarded@example.com']
         attachments:
           type: array
           items:


### PR DESCRIPTION
This is the spec half of DEV-1626.

`received_for` is documented on [Retrieve received email](https://resend.com/docs/api-reference/emails/retrieve-received-email) as "the recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers", but it was missing from the spec. Adds it in two places:

- `GetReceivedEmailResponse`, the retrieve endpoint response, which is what the issue reported.
- `EmailReceivedEventData`, the `email.received` webhook payload, which has the same gap. Node, Python, Rust, Java, and .NET all already decode `received_for` from webhook events.

Only `resend.yaml` is touched, per the readme. `resend.json` regenerates on merge, and I confirmed `yq -o=json resend.yaml` still converts cleanly.

### Two judgment calls worth a reviewer's eye

**Nullability.** I used a plain `type: array` rather than the `type: [array, "null"]` that the neighbouring `bcc`/`cc`/`reply_to` use in `GetReceivedEmailResponse`. Every SDK types this as a non-nullable list, and resend-node's fixtures use `received_for: []` for the no-forwarding case, which suggests an empty array rather than null. I could not verify against a live response.

**Not marked required.** In `EmailReceivedEventData` I left `received_for` out of the `required` list even though `bcc` and `cc` are in it. resend-rust puts `#[serde(default)]` on this field in both its inbound and webhook types while leaving `bcc`/`cc` without one, which reads as deliberate defensiveness about the field being absent. Marking it required is the stronger claim, so I took the safe side. If it is in fact always present, say so and I will add it.

Ref DEV-1626