### PR TITLE
fix: allow null contact first_name and last_name in response schemas

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -3400,12 +3400,12 @@ components:
           description: Email address of the contact.
           example: steve.wozniak@gmail.com
         first_name:
-          type: string
-          description: First name of the contact.
+          type: [string, "null"]
+          description: First name of the contact. Null when the contact has no first name.
           example: Steve
         last_name:
-          type: string
-          description: Last name of the contact.
+          type: [string, "null"]
+          description: Last name of the contact. Null when the contact has no last name.
           example: Wozniak
         created_at:
           type: string
@@ -3490,12 +3490,12 @@ components:
                 description: Email address of the contact.
                 example: steve.wozniak@gmail.com
               first_name:
-                type: string
-                description: First name of the contact.
+                type: [string, "null"]
+                description: First name of the contact. Null when the contact has no first name.
                 example: Steve
               last_name:
-                type: string
-                description: Last name of the contact.
+                type: [string, "null"]
+                description: Last name of the contact. Null when the contact has no last name.
                 example: Wozniak
               created_at:
                 type: string
@@ -6067,11 +6067,11 @@ components:
           type: string
           description: Contact's email address.
         first_name:
-          type: string
-          description: Contact's first name.
+          type: [string, "null"]
+          description: Contact's first name. Null when the contact has no first name.
         last_name:
-          type: string
-          description: Contact's last name.
+          type: [string, "null"]
+          description: Contact's last name. Null when the contact has no last name.
         unsubscribed:
           type: boolean
           description: Whether the contact has unsubscribed from all emails sent from your team.

--- a/resend.yaml
+++ b/resend.yaml
@@ -3401,11 +3401,11 @@ components:
           example: steve.wozniak@gmail.com
         first_name:
           type: [string, "null"]
-          description: First name of the contact. Null when the contact has no first name.
+          description: First name of the contact.
           example: Steve
         last_name:
           type: [string, "null"]
-          description: Last name of the contact. Null when the contact has no last name.
+          description: Last name of the contact.
           example: Wozniak
         created_at:
           type: string
@@ -3491,11 +3491,11 @@ components:
                 example: steve.wozniak@gmail.com
               first_name:
                 type: [string, "null"]
-                description: First name of the contact. Null when the contact has no first name.
+                description: First name of the contact.
                 example: Steve
               last_name:
                 type: [string, "null"]
-                description: Last name of the contact. Null when the contact has no last name.
+                description: Last name of the contact.
                 example: Wozniak
               created_at:
                 type: string
@@ -6068,10 +6068,10 @@ components:
           description: Contact's email address.
         first_name:
           type: [string, "null"]
-          description: Contact's first name. Null when the contact has no first name.
+          description: Contact's first name.
         last_name:
           type: [string, "null"]
-          description: Contact's last name. Null when the contact has no last name.
+          description: Contact's last name.
         unsubscribed:
           type: boolean
           description: Whether the contact has unsubscribed from all emails sent from your team.

--- a/resend.yaml
+++ b/resend.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.2
 info:
   title: Resend
-  version: 1.5.0
+  version: 1.5.1
   description: 'Resend is the email platform for developers.'
 servers:
   - url: https://api.resend.com


### PR DESCRIPTION
Contact `first_name` and `last_name` were declared as plain `type: string`, but the API returns `null` when a contact has no name. Strict deserializers reject that, which is what Tony hit in Rust.

Changed to `type: [string, "null"]` in the three schemas that carry a contact back to the caller:

- `GetContactResponseSuccess`
- `ListContactsResponseSuccess`, on the `data` item
- `ContactEventData`, the payload for `contact.created` / `contact.updated` / `contact.deleted`

`type: [string, "null"]` is the 3.1 form, which is what this spec is already on (`openapi: 3.1.2`, 29 existing uses versus 10 legacy `nullable: true`). Neither name appears in `ContactEventData.required`, so nothing needed to move there. `CreateContactResponseSuccess` and `UpdateContactResponseSuccess` only return `object` and `id`, so they were already fine.

Only `resend.yaml` is touched, per the readme, and `yq -o=json resend.yaml` still converts cleanly.

### Left alone deliberately

`CreateContactOptions` and `UpdateContactOptions` still declare both names as non-nullable. Those are request bodies, so this is a different question: it turns on whether the API accepts an explicit `null` to clear a name on update, which I could not verify. If it does, say so and I will widen them in the same PR.

Ref DEV-1625

---

**Confirmed against the monorepo.** The producer schema at `packages/inngest/src/schemas/contacts.ts:104` declares `firstName: z.string().nullish()` / `lastName: z.string().nullish()`, which is Zod for `string | null | undefined`, and `apps/background-jobs/src/inngest/functions/webhooks/contact-events-webhook.ts:91` forwards the value to Svix uncoalesced. So on `ContactEventData` all three states are reachable: the key can be absent, present-and-null, or a string. Leaving both names out of `required` while making the type nullable is therefore correct rather than merely cautious.


## Version bump

Includes a patch bump to `1.5.1` in `resend.yaml`. This repo normally bumps in a separate `chore:` PR, so drop that commit if you would rather keep the split.
