### PR TITLE
feat: add emails/{email_id}/share endpoint

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -146,6 +146,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Email'
+  /emails/{email_id}/share:
+    post:
+      operationId: emails/share
+      tags:
+        - Emails
+      summary: Create a shareable link for a sent or received email.
+      parameters:
+        - name: email_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the email.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ShareEmailOptions'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ShareEmailResponse'
   /emails/batch:
     post:
       operationId: emails/send-batch
@@ -2587,6 +2613,27 @@ components:
         scheduled_at:
           type: string
           description: Schedule email to be sent later. The date should be in ISO 8601 format.
+    ShareEmailOptions:
+      type: object
+      properties:
+        expires_in:
+          type: string
+          description: How long the link stays valid for, as a duration like `10m`, `2 hours`, or `1 day`. Defaults to `48h` and cannot exceed 48 hours.
+    ShareEmailResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: The type of object.
+          example: 'email'
+        id:
+          type: string
+          description: The ID of the email.
+          example: '4ef9a417-02e9-4d39-ad75-9611e0fcc33c'
+        url:
+          type: string
+          description: The shareable link, valid until it expires.
+          example: 'https://resend.com/shared?token=eyJhbGciOiJIUzI1NiJ9...'
     Email:
       type: object
       properties:


### PR DESCRIPTION
Adds `POST /emails/{email_id}/share` — creates a shareable link for a sent or received email. 

Optional body: `expires_in` (human-readable duration, e.g. `10m`, `2 hours`, `1 day`; default `48h`, capped at 48h).

`resend.json` intentionally not touched — CI regenerates it via a separate PR on merge to `main`, per this repo's own convention.