### PR TITLE
feat: add api-keys/{api_key_id} PATCH endpoint

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -597,6 +597,30 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListApiKeysResponse'
   /api-keys/{api_key_id}:
+    patch:
+      operationId: api-keys/update
+      tags:
+        - API Keys
+      summary: Update an existing API key
+      parameters:
+        - name: api_key_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The API key ID.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateApiKeyRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateApiKeyResponse'
     delete:
       operationId: api-keys/remove
       tags:
@@ -3236,6 +3260,24 @@ components:
           type: boolean
           description: Indicates whether the API key was successfully deleted.
           example: true
+    UpdateApiKeyRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The API key name.
+    UpdateApiKeyResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: The type of object.
+          example: 'api_key'
+        id:
+          type: string
+          description: The ID of the API key.
     CreateAudienceOptions:
       type: object
       deprecated: true


### PR DESCRIPTION
## Summary
- Adds `PATCH /api-keys/{api_key_id}` to the spec (`operationId: api-keys/update`), matching the API's new endpoint — documented at https://resend.com/docs/api-reference/api-keys/update-api-key.
- Adds `UpdateApiKeyRequest` (`name` only, required) and `UpdateApiKeyResponse` (`{object, id}`) schemas, mirroring `UpdateWebhookRequest`/`UpdateWebhookResponse`'s shape.
- `permission`/`domain_id` are intentionally not part of the request schema — the endpoint doesn't accept them (prevents a leaked management key from silently widening another key's scope).
- Only `resend.yaml` is touched; `resend.json` is auto-regenerated by CI on push to `main` per this repo's existing workflow, not by this PR.

Draft — SDK rollout in progress, tracked in Linear as DEV-1219.

## Test plan
- [x] `yq -o=json resend.yaml` converts cleanly (verified locally)
- [ ] CI's `generate-json.yml` regenerates `resend.json` once merged to `main`