### PR TITLE
fix: say that the email filter on broadcast recipients is a substring match

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -1388,7 +1388,7 @@ paths:
           required: false
           schema:
             type: string
-          description: Filter recipients by email address.
+          description: Filter recipients whose email address contains this value.
         - name: bounce_type
           in: query
           required: false


### PR DESCRIPTION
## What

Reword the `email` query parameter description on `GET /broadcasts/{id}/recipients` from "Filter recipients by email address." to "Filter recipients whose email address contains this value."

## Why

The live API matches by substring: `email=deliver` returns `delivered@resend.dev`. The docs page and the doc comments in go, python, dotnet, java, rust, and the CLI already describe the substring behavior. The spec was the surface that undersold it. Follow-up from the review of the #97 rollout batch.