### PR TITLE
fix: align webhooks, logs, and suppressions with the API

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -1462,6 +1462,8 @@ paths:
           required: false
           schema:
             type: integer
+            minimum: 1
+            maximum: 100
           description: Maximum number of webhooks to return.
         - name: after
           in: query
@@ -4633,7 +4635,7 @@ components:
       properties:
         endpoint:
           type: string
-          description: The URL where webhook events will be sent.
+          description: The URL where webhook events will be sent. Must use the https scheme.
           example: 'https://webhook.example.com/handler'
         events:
           type: array
@@ -4737,7 +4739,7 @@ components:
       properties:
         endpoint:
           type: string
-          description: The URL where webhook events will be sent.
+          description: The URL where webhook events will be sent. Must use the https scheme.
           example: 'https://webhook.example.com/new-handler'
         events:
           type: array
@@ -5632,8 +5634,8 @@ components:
           type: [string, "null"]
           description: The user agent of the request.
         request_body:
-          type: [object, "null"]
-          description: The request body sent to the API.
+          type: [object, array, "null"]
+          description: The request body sent to the API. Endpoints that accept a top-level array, such as `POST /emails/batch`, log an array.
         response_body:
           type: [object, "null"]
           description: The response body returned by the API.
@@ -7020,8 +7022,7 @@ components:
           description: Origin of the suppression.
           example: manual
         source_id:
-          type: string
-          nullable: true
+          type: [string, "null"]
           description: Identifier of the event that caused the suppression, such as the email that bounced or complained.
           example: 479e3145-dd38-476b-932c-529ceb705947
         created_at:
@@ -7061,8 +7062,7 @@ components:
                 description: Origin of the suppression.
                 example: manual
               source_id:
-                type: string
-                nullable: true
+                type: [string, "null"]
                 description: Identifier of the event that caused the suppression, such as the email that bounced or complained.
                 example: 479e3145-dd38-476b-932c-529ceb705947
               created_at:


### PR DESCRIPTION
Part of the API drift sweep, batch 5: suppressions, webhooks, events, and logs. The API code at monorepo `d595d22` is the source of truth.

## Fixes

- Suppressions: convert two `nullable: true` (OpenAPI 3.0 syntax) on `source_id` to `type: [string, "null"]`. This removes two lint errors. This is the carry-over from the batch 1 sweep.
- `GET /webhooks`: add `minimum: 1` and `maximum: 100` to the inline `limit` parameter. The shared pagination schema enforces these bounds.
- `Log.request_body`: allow arrays. The API logs the raw request body, and batch endpoints send a top-level array.
- Webhook `endpoint` field: document the https requirement. The create and update validations reject other schemes.

## Verified against the code, no change needed

Events (`POST /events`, `GET /events`, `POST /events/send`, `GET|PATCH|DELETE /events/{identifier}`) and logs (`GET /logs`, `GET /logs/{log_id}`) match the code. The webhooks CRUD matches the code.

## Out of scope

The webhook events endpoints (`GET /webhooks/{webhook_id}/events`, `GET .../events/{event_id}`, `GET .../events/{event_id}/attempts`) stay out of this PR. The docs mark them private beta. PR #106 covers them for when they go GA.

## Lint

Errors go from 10 to 8, warnings stay at 125. The 8 remaining errors are the emails attachment `nullable` fields, which belong to the batch 1 scope.