### PR TITLE
feat: add webhook event listing endpoints

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -1550,6 +1550,95 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteWebhookResponse'
+  /webhooks/{webhook_id}/events:
+    get:
+      operationId: webhooks/list-events
+      tags:
+        - Webhooks
+      summary: Retrieve a list of webhook events
+      parameters:
+        - name: webhook_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The Webhook ID.
+        - $ref: '#/components/parameters/PaginationLimit'
+        - name: after
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Pagination cursor to fetch results after this webhook event ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListWebhookEventsResponse'
+  /webhooks/{webhook_id}/events/{event_id}:
+    get:
+      operationId: webhooks/get-event
+      tags:
+        - Webhooks
+      summary: Retrieve a single webhook event
+      parameters:
+        - name: webhook_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The Webhook ID.
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Webhook Event ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetWebhookEventResponse'
+  /webhooks/{webhook_id}/events/{event_id}/attempts:
+    get:
+      operationId: webhooks/list-event-attempts
+      tags:
+        - Webhooks
+      summary: Retrieve a list of webhook event attempts
+      parameters:
+        - name: webhook_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The Webhook ID.
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Webhook Event ID.
+        - $ref: '#/components/parameters/PaginationLimit'
+        - name: after
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Pagination cursor to fetch results after this webhook event attempt ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListWebhookEventAttemptsResponse'
   /segments:
     post:
       operationId: segments/create
@@ -4781,6 +4870,112 @@ components:
           type: boolean
           description: Indicates whether the webhook was successfully deleted.
           example: true
+    ListWebhookEventsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: 'list'
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+          example: false
+        data:
+          type: array
+          description: Array containing webhook event information.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: The ID of the webhook event.
+                example: 'msg_2vY8PezvvzTiCLILH2T3F1its6A'
+              type:
+                type: string
+                description: The type of the event.
+                example: 'email.sent'
+              created_at:
+                type: string
+                description: Timestamp indicating when the event was created.
+                example: '2025-08-25T14:00:00.000Z'
+              status:
+                type: string
+                enum:
+                  - pending
+                  - attempting
+                  - success
+                  - failed
+                description: The delivery status of the event for this webhook.
+                example: 'success'
+    GetWebhookEventResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: The type of object.
+          example: 'webhook_event'
+        id:
+          type: string
+          description: The ID of the webhook event.
+          example: 'msg_2vY8PezvvzTiCLILH2T3F1its6A'
+        type:
+          type: string
+          description: The type of the event.
+          example: 'email.sent'
+        created_at:
+          type: string
+          description: Timestamp indicating when the event was created.
+          example: '2025-08-25T14:00:00.000Z'
+        status:
+          type: string
+          enum:
+            - pending
+            - attempting
+            - success
+            - failed
+          description: The delivery status of the event for this webhook.
+          example: 'success'
+        next_attempt_at:
+          type: [string, "null"]
+          description: Timestamp of the next delivery attempt. Null once the event has succeeded or permanently failed.
+          example: null
+        payload:
+          type: object
+          description: The event payload sent to the webhook endpoint.
+    ListWebhookEventAttemptsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: Type of the response object.
+          example: 'list'
+        has_more:
+          type: boolean
+          description: Indicates if there are more results available.
+          example: false
+        data:
+          type: array
+          description: Array containing webhook event attempt information.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: The ID of the webhook event attempt.
+                example: 'atmpt_2vY8PezvvzTiCLILH2T3F1its6A'
+              http_status_code:
+                type: integer
+                description: The HTTP status code returned by the webhook endpoint.
+                example: 200
+              response:
+                type: string
+                description: The response body returned by the webhook endpoint.
+                example: 'OK'
+              sent_at:
+                type: string
+                description: Timestamp indicating when the attempt was sent.
+                example: '2025-08-25T14:00:00.000Z'
     TemplateVariable:
       type: object
       properties:

--- a/resend.yaml
+++ b/resend.yaml
@@ -1565,12 +1565,7 @@ paths:
             format: uuid
           description: The Webhook ID.
         - $ref: '#/components/parameters/PaginationLimit'
-        - name: after
-          in: query
-          required: false
-          schema:
-            type: string
-          description: Pagination cursor to fetch results after this webhook event ID.
+        - $ref: '#/components/parameters/PaginationAfter'
       responses:
         '200':
           description: OK
@@ -1626,12 +1621,7 @@ paths:
             type: string
           description: The Webhook Event ID.
         - $ref: '#/components/parameters/PaginationLimit'
-        - name: after
-          in: query
-          required: false
-          schema:
-            type: string
-          description: Pagination cursor to fetch results after this webhook event attempt ID.
+        - $ref: '#/components/parameters/PaginationAfter'
       responses:
         '200':
           description: OK
@@ -4890,15 +4880,16 @@ components:
               id:
                 type: string
                 description: The ID of the webhook event.
-                example: 'msg_2vY8PezvvzTiCLILH2T3F1its6A'
+                example: 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2'
               type:
                 type: string
                 description: The type of the event.
                 example: 'email.sent'
               created_at:
                 type: string
+                format: date-time
                 description: Timestamp indicating when the event was created.
-                example: '2025-08-25T14:00:00.000Z'
+                example: '2026-08-22T15:28:00.000Z'
               status:
                 type: string
                 enum:
@@ -4918,15 +4909,16 @@ components:
         id:
           type: string
           description: The ID of the webhook event.
-          example: 'msg_2vY8PezvvzTiCLILH2T3F1its6A'
+          example: 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2'
         type:
           type: string
           description: The type of the event.
           example: 'email.sent'
         created_at:
           type: string
+          format: date-time
           description: Timestamp indicating when the event was created.
-          example: '2025-08-25T14:00:00.000Z'
+          example: '2026-08-22T15:28:00.000Z'
         status:
           type: string
           enum:
@@ -4935,14 +4927,24 @@ components:
             - success
             - failed
           description: The delivery status of the event for this webhook.
-          example: 'success'
+          example: 'attempting'
         next_attempt_at:
           type: [string, "null"]
-          description: Timestamp of the next delivery attempt. Null once the event has succeeded or permanently failed.
-          example: null
+          format: date-time
+          description: Timestamp of the next scheduled delivery attempt, or null when none is scheduled. Always null once the event has succeeded or permanently failed.
+          example: '2026-08-22T15:33:00.000Z'
         payload:
           type: object
           description: The event payload sent to the webhook endpoint.
+          example:
+            type: 'email.sent'
+            created_at: '2026-08-22T15:28:00.000Z'
+            data:
+              email_id: '571f1f42-1c2d-4b1f-8f8e-8b3b5b3b5b3b'
+              from: 'onboarding@resend.dev'
+              to: ['delivered@resend.dev']
+              subject: 'Welcome'
+              created_at: '2026-08-22T15:27:59.000Z'
     ListWebhookEventAttemptsResponse:
       type: object
       properties:
@@ -4963,7 +4965,7 @@ components:
               id:
                 type: string
                 description: The ID of the webhook event attempt.
-                example: 'atmpt_2vY8PezvvzTiCLILH2T3F1its6A'
+                example: 'atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2'
               http_status_code:
                 type: integer
                 description: The HTTP status code returned by the webhook endpoint.
@@ -4971,11 +4973,12 @@ components:
               response:
                 type: string
                 description: The response body returned by the webhook endpoint.
-                example: 'OK'
+                example: '{"ok":true}'
               sent_at:
                 type: string
+                format: date-time
                 description: Timestamp indicating when the attempt was sent.
-                example: '2025-08-25T14:00:00.000Z'
+                example: '2026-08-22T15:33:12.000Z'
     TemplateVariable:
       type: object
       properties:


### PR DESCRIPTION
Adds the three webhook event listing endpoints shipped in the public API (GA — the feature flag was removed in resend/resend-monorepo#8901):

- `GET /webhooks/{webhook_id}/events` — list a webhook's events, `after`-only cursor pagination
- `GET /webhooks/{webhook_id}/events/{event_id}` — event details, including `next_attempt_at` (null when no attempt is scheduled, always null once the event is terminal) and the delivered `payload`
- `GET /webhooks/{webhook_id}/events/{event_id}/attempts` — list an event's delivery attempts, `after`-only cursor pagination

Schemas mirror the response types in `apps/public-api` (resend/resend-monorepo#7466, #7717, #7721, #7751, #7766, #7941). Examples match the API reference pages in resend-docs (#1717, #1721), which are already live and tagged BETA — the endpoints enter the spec now because the SDK rollout builds from it. `payload` is typed `object`: the impl types it `unknown`, but every delivered payload is our own webhook envelope (`{type, created_at, data}`).

Evidence: `yq` parses the file; `redocly lint` shows the same 10 pre-existing errors as main and no new ones (+3 warnings from the missing-4XX rule that every operation in the file trips).

Part of the rollout tracked in DEV-1919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Linear: https://linear.app/resend/issue/DEV-1920
