### PR TITLE
fix: update segments property on contact create to accept objects with IDs

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -3817,7 +3817,11 @@ components:
         segments:
           type: array
           items:
-            type: string
+            type: object
+            properties:
+              id:
+                type: string
+                description: The segment ID
           description: Array of segment IDs to add the contact to.
         topics:
           type: array


### PR DESCRIPTION
The [segments property is an array of objects with IDs](https://resend.com/docs/api-reference/contacts/create-contact#param-segments), the API doesn't accept an array of strings.