### PR TITLE
feat: add webhook event replay endpoint

### DIFF
--- a/resend.yaml
+++ b/resend.yaml
@@ -1600,35 +1600,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetWebhookEventResponse'
-  /webhooks/{webhook_id}/events/{event_id}/attempts:
-    get:
-      operationId: webhooks/list-event-attempts
-      tags:
-        - Webhooks
-      summary: Retrieve a list of webhook event attempts
-      parameters:
-        - name: webhook_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-          description: The Webhook ID.
-        - name: event_id
-          in: path
-          required: true
-          schema:
-            type: string
-          description: The Webhook Event ID.
-        - $ref: '#/components/parameters/PaginationLimit'
-        - $ref: '#/components/parameters/PaginationAfter'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListWebhookEventAttemptsResponse'
   /webhooks/{webhook_id}/events/{event_id}/replay:
     post:
       operationId: webhooks/replay-event
@@ -1661,6 +1632,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReplayWebhookEventResponse'
+  /webhooks/{webhook_id}/events/{event_id}/attempts:
+    get:
+      operationId: webhooks/list-event-attempts
+      tags:
+        - Webhooks
+      summary: Retrieve a list of webhook event attempts
+      parameters:
+        - name: webhook_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The Webhook ID.
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Webhook Event ID.
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationAfter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListWebhookEventAttemptsResponse'
   /segments:
     post:
       operationId: segments/create

--- a/resend.yaml
+++ b/resend.yaml
@@ -1629,6 +1629,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListWebhookEventAttemptsResponse'
+  /webhooks/{webhook_id}/events/{event_id}/replay:
+    post:
+      operationId: webhooks/replay-event
+      tags:
+        - Webhooks
+      summary: Replay a webhook event
+      description: >-
+        Queues one more delivery of the event to the webhook. The event must be
+        retrievable through the get event endpoint and the webhook must be enabled;
+        a disabled webhook returns a 422 validation_error. A manual replay does not
+        schedule automatic retries.
+      parameters:
+        - name: webhook_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The Webhook ID.
+        - name: event_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The Webhook Event ID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReplayWebhookEventResponse'
   /segments:
     post:
       operationId: segments/create
@@ -5007,6 +5039,17 @@ components:
                 format: date-time
                 description: Timestamp indicating when the attempt was sent.
                 example: '2026-08-22T15:33:12.000Z'
+    ReplayWebhookEventResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          description: The type of object.
+          example: 'webhook_event'
+        id:
+          type: string
+          description: The ID of the replayed webhook event.
+          example: 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2'
     TemplateVariable:
       type: object
       properties:


### PR DESCRIPTION
Adds \`POST /webhooks/{webhook_id}/events/{event_id}/replay\` (operationId \`webhooks/replay-event\`), shipped in the public API in resend/resend-monorepo#9535.

The response schema mirrors \`ReplayWebhookEventSuccessfulResponse\` in \`apps/public-api/src/types/webhooks/replay-webhook-event.ts\`: \`{ object: 'webhook_event', id }\`. The description states the two conditions the route enforces: the event resolves through the same \`findWebhookEvent\` lookup as the get event endpoint, and the webhook must be enabled (422 \`validation_error\` otherwise).

Evidence: \`yq\` parses the file; \`redocly lint\` shows the same 10 pre-existing errors as main, plus one warning from the missing-4XX rule that every operation trips.

Part of the rollout tracked in DEV-2005.

Linear: https://linear.app/resend/issue/DEV-2006